### PR TITLE
Network address change from short to int

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -301,7 +301,7 @@ public class ZigBeeConsole {
             write("Network Address  : " + device.getNetworkAddress());
             write("Extended Address : " + device.getIEEEAddress());
             write("Endpoint Address : " + device.getEndPointAddress());
-            write("Device Type      : " + ZigBeeApiConstants.getDeviceName(device.getDeviceTypeId()));
+            write("Device Type      : " + device.getDeviceType());
             write("Device Category  : " + ZigBeeApiConstants.getCategoryDeviceName(device.getDeviceTypeId()));
             write("Device Version   : " + device.getDeviceVersion());
             write("Input Clusters   : ");

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -369,13 +369,13 @@ public class ZigBeeConsole {
                 return false;
             }
 
-            write("Network Address  : " + device.getNetworkAddress());
-            write("Extended Address : " + device.getIEEEAddress());
-            write("Endpoint Address : " + device.getEndPointAddress());
-            write("Device Type      : " + device.getDeviceType());
-            write("Device Category  : " + ZigBeeApiConstants.getCategoryDeviceName(device.getDeviceTypeId()));
-            write("Device Version   : " + device.getDeviceVersion());
-            write("Input Clusters   : ");
+            print("Network Address  : " + device.getNetworkAddress());
+            print("Extended Address : " + device.getIEEEAddress());
+            print("Endpoint Address : " + device.getEndPointAddress());
+            print("Device Type      : " + device.getDeviceType());
+            print("Device Category  : " + ZigBeeApiConstants.getCategoryDeviceName(device.getDeviceTypeId()));
+            print("Device Version   : " + device.getDeviceVersion());
+            print("Input Clusters   : ");
             for (int c : device.getInputClusters()) {
                 final Cluster cluster = device.getCluster(c);
                 print("                 : " + c + " " + ZigBeeApiConstants.getClusterName(c));

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -354,7 +354,9 @@ public class ZigBeeConsole {
             final List<Device> devices = zigbeeApi.getDevices();
             for (int i = 0; i < devices.size(); i++) {
                 final Device device = devices.get(i);
-                System.out.println(i + ") " + device.getEndpointId() + " : " + device.getDeviceType());
+                System.out.println(i + ") " + device.getEndpointId() +
+                		" [" + device.getNetworkAddress() + "]" +
+                		" : " + device.getDeviceType());
             }
             return true;
         }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/af/AF_INCOMING_MSG.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/af/AF_INCOMING_MSG.java
@@ -144,8 +144,8 @@ public class AF_INCOMING_MSG extends ZToolPacket /*implements IINDICATION,IAF*/ 
         return (byte) super.packet[ZToolPacket.PAYLOAD_START_INDEX + 7];
     }
 
-    public short getSrcAddr() {
-        return (short) ((super.packet[ZToolPacket.PAYLOAD_START_INDEX + 5] << 8)
+    public int getSrcAddr() {
+        return (int) ((super.packet[ZToolPacket.PAYLOAD_START_INDEX + 5] << 8)
                 + (super.packet[ZToolPacket.PAYLOAD_START_INDEX + 4]));
     }
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_IEEE_ADDR_REQ.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_IEEE_ADDR_REQ.java
@@ -69,7 +69,7 @@ public class ZDO_IEEE_ADDR_REQ extends ZToolPacket /*implements IREQUEST,IZDo*/ 
     }
 
 
-    public ZDO_IEEE_ADDR_REQ(short nwkAddress, REQ_TYPE type, byte startIndex) {
+    public ZDO_IEEE_ADDR_REQ(int nwkAddress, REQ_TYPE type, byte startIndex) {
         int[] framedata = new int[4];
         framedata[0] = Integers.getByteAsInteger(nwkAddress, 0);
         framedata[1] = Integers.getByteAsInteger(nwkAddress, 1);

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/serial/ZigBeeNetworkManagerSerialImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/serial/ZigBeeNetworkManagerSerialImpl.java
@@ -1524,11 +1524,11 @@ public class ZigBeeNetworkManagerSerialImpl implements ZigBeeNetworkManager {
                 if (listners.isEmpty()) {
                     logger.warn("Received AF_INCOMING_MSG but no listeners. " +
                                     "Message was from {} and cluster {} to end point {}. Data: {}",
-                            NetworkAddressUtil.shortToInt(msg.getSrcAddr()), msg.getClusterId(),
+                            msg.getSrcAddr(), msg.getClusterId(),
                             msg.getDstEndpoint(), msg);
                 } else {
                     logger.debug("Received AF_INCOMING_MSG from {} and cluster {} to end point {}. Data: {}",
-                            NetworkAddressUtil.shortToInt(msg.getSrcAddr()), msg.getClusterId(),
+                            msg.getSrcAddr(), msg.getClusterId(),
                             msg.getDstEndpoint(), msg);
                 }
                 ArrayList<ApplicationFrameworkMessageListener> localCopy = null;


### PR DESCRIPTION
Change network address from short to int.
This is consistent with the rest of the library, and returning a short can cause an exception if the top bit is set.
The library currently seems to treat the address as short when it first reads them then has helper methods to print them as ints, then ultimately changes them to an int anyway, so it seems like it should be an int from the beginning?