### PR TITLE
Support Z-Stack 2.6.x firmware

### DIFF
--- a/zigbee-api/build.gradle
+++ b/zigbee-api/build.gradle
@@ -8,5 +8,6 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version:'2.4'
     compile group: 'commons-lang', name: 'commons-lang', version:'2.6'
     compile group: 'commons-codec', name: 'commons-codec', version:'1.8'
+    compile group: 'com.google.collections', name: 'google-collections', version: '1.0-rc2'
     testCompile group: 'org.easymock', name: 'easymock', version:'3.2'
 }

--- a/zigbee-api/pom.xml
+++ b/zigbee-api/pom.xml
@@ -68,6 +68,12 @@
             <version>1.8</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.collections</groupId>
+            <artifactId>google-collections</artifactId>
+            <version>1.0-rc2</version>
+        </dependency>
+
     </dependencies>
     
 </project>

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolCMD.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolCMD.java
@@ -659,6 +659,9 @@ public class ZToolCMD {
     /// <name>TI.ZPI2.MESSAGE_ID.ZDO_STATUS_ERROR_RSP</name>
     /// <summary>This message is the default message for error status.</summary>
     public static final int ZDO_STATUS_ERROR_RSP = 0x45c3;
+    /// <name>TI.ZPI2.MESSAGE_ID.ZDO_TC_DEVICE_IND</name>
+    /// <summary>ZDO Trust Center end device announce indication.</summary>
+    public static final int ZDO_TC_DEVICE_IND = 0x45ca;
     /// <name>TI.ZPI2.MESSAGE_ID.ZDO_UNBIND_REQ</name>
     /// <summary>This command is generated to request an UnBind</summary>
     public static final int ZDO_UNBIND_REQ = 0x2522;

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolCMD.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolCMD.java
@@ -593,6 +593,15 @@ public class ZToolCMD {
     /// <name>TI.ZPI2.MESSAGE_ID.ZDO_MGMT_RTG_RSP</name>
     /// <summary>This callback message is in response to the ZDO Management Routing Table Request. </summary>
     public static final int ZDO_MGMT_RTG_RSP = 0x45b2;
+    /// <name>TI.ZPI2.MESSAGE_ID.ZDO_MSG_CB_REGISTER</name>
+    /// <summary>This command registers for a ZDO callback.</summary>
+    public static final int ZDO_MSG_CB_REGISTER = 0x253e;
+    /// <name>TI.ZPI2.MESSAGE_ID.ZDO_MSG_CB_REGISTER_SRSP</name>
+    /// <summary>Response for ZDO_MSG_CB_REGISTER.</summary>
+    public static final int ZDO_MSG_CB_REGISTER_SRSP = 0x653e;
+    /// <name>TI.ZPI2.MESSAGE_ID.ZDO_MSG_CB_INCOMING</name>
+    /// <summary>This callback message contains a ZDO cluster response.</summary>
+    public static final int ZDO_MSG_CB_INCOMING = 0x45ff;
     /// <name>TI.ZPI2.MESSAGE_ID.ZDO_NODE_DESC_REQ</name>
     /// <summary>This command is generated to inquire as to the Node Descriptor of the destination device</summary>
     public static final int ZDO_NODE_DESC_REQ = 0x2502;

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacket.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacket.java
@@ -144,6 +144,10 @@ public class ZToolPacket {
         return this.FCS;
     }
 
+    public void setFCS(int fcs) {
+        this.FCS = fcs;
+    }
+
     public static boolean isSpecialByte(int b) {
         if (b == ZToolPacket.START_BYTE) {
             return true;

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketStream.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketStream.java
@@ -321,6 +321,8 @@ public class ZToolPacketStream
                 return new ZDO_SIMPLE_DESC_RSP(payload);
             case ZToolCMD.ZDO_STATE_CHANGE_IND:
                 return new ZDO_STATE_CHANGE_IND(payload);
+            case ZToolCMD.ZDO_TC_DEVICE_IND:
+                return new ZDO_TC_DEVICE_IND(payload);
             case ZToolCMD.ZDO_UNBIND_REQ_SRSP:
                 return new ZDO_UNBIND_REQ_SRSP(payload);
             case ZToolCMD.ZDO_UNBIND_RSP:

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketStream.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketStream.java
@@ -302,6 +302,11 @@ public class ZToolPacketStream
                 return new ZDO_MGMT_PERMIT_JOIN_REQ_SRSP(payload);
             case ZToolCMD.ZDO_MGMT_PERMIT_JOIN_RSP:
                 return new ZDO_MGMT_PERMIT_JOIN_RSP(payload);
+            case ZToolCMD.ZDO_MSG_CB_REGISTER_SRSP:
+                return new ZDO_MSG_CB_REGISTER_SRSP(payload);
+            case ZToolCMD.ZDO_MSG_CB_INCOMING:
+                ZDO_MSG_CB_INCOMING incoming = new ZDO_MSG_CB_INCOMING(payload);
+                return incoming.translate();
             case ZToolCMD.ZDO_NODE_DESC_REQ_SRSP:
                 return new ZDO_NODE_DESC_REQ_SRSP(payload);
             case ZToolCMD.ZDO_NODE_DESC_RSP:

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/af/AF_INCOMING_MSG.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/af/AF_INCOMING_MSG.java
@@ -113,7 +113,7 @@ public class AF_INCOMING_MSG extends ZToolPacket /*implements IINDICATION,IAF*/ 
         this.Timestamp = ByteUtils.convertMultiByteToLong(bytes);
         this.TransSeqNumber = framedata[15];
         this.Len = framedata[16];
-        this.Data = new int[framedata.length - 17];
+        this.Data = new int[this.Len];
         for (int i = 0; i < this.Data.length; i++) {
             this.Data[i] = framedata[17 + i];
         }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MGMT_PERMIT_JOIN_REQ.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MGMT_PERMIT_JOIN_REQ.java
@@ -23,6 +23,7 @@
 
 package org.bubblecloud.zigbee.network.packet.zdo;
 
+import org.bubblecloud.zigbee.network.packet.ZToolAddress;
 import org.bubblecloud.zigbee.network.packet.ZToolAddress16;
 import org.bubblecloud.zigbee.network.packet.ZToolCMD;
 import org.bubblecloud.zigbee.network.packet.ZToolPacket;
@@ -33,6 +34,9 @@ import org.bubblecloud.zigbee.util.DoubleByte;
  * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)
  */
 public class ZDO_MGMT_PERMIT_JOIN_REQ extends ZToolPacket /*implements IREQUEST,IZDO*/ {
+    /// <name>TI.ZPI1.ZDO_MGMT_PERMIT_JOIN_REQ.AddrMode</name>
+    /// <summary>Destination address type: 0x02 – Address 16 bit, 0x0F – Broadcast.</summary>
+    public byte AddrMode;
     /// <name>TI.ZPI1.ZDO_MGMT_PERMIT_JOIN_REQ.DstAddr</name>
     /// <summary>Destination network address.</summary>
     public ZToolAddress16 DstAddr;
@@ -50,16 +54,18 @@ public class ZDO_MGMT_PERMIT_JOIN_REQ extends ZToolPacket /*implements IREQUEST,
 
     /// <name>TI.ZPI1.ZDO_MGMT_PERMIT_JOIN_REQ</name>
     /// <summary>Constructor</summary>
-    public ZDO_MGMT_PERMIT_JOIN_REQ(ZToolAddress16 num1, int num2, int num3) {
-        this.DstAddr = num1;
-        this.Duration = num2;
-        this.TCSignificance = num3;
+    public ZDO_MGMT_PERMIT_JOIN_REQ(byte num1, ZToolAddress16 num2, int num3, int num4) {
+        this.AddrMode = num1;
+        this.DstAddr = num2;
+        this.Duration = num3;
+        this.TCSignificance = num4;
 
-        int[] framedata = new int[4];
-        framedata[0] = this.DstAddr.getLsb();
-        framedata[1] = this.DstAddr.getMsb();
-        framedata[2] = this.Duration;
-        framedata[3] = this.TCSignificance;
+        int[] framedata = new int[5];
+        framedata[0] = this.AddrMode;
+        framedata[1] = this.DstAddr.getLsb();
+        framedata[2] = this.DstAddr.getMsb();
+        framedata[3] = this.Duration;
+        framedata[4] = this.TCSignificance;
         super.buildPacket(new DoubleByte(ZToolCMD.ZDO_MGMT_PERMIT_JOIN_REQ), framedata);
     }
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_INCOMING.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_INCOMING.java
@@ -43,6 +43,7 @@ public class ZDO_MSG_CB_INCOMING extends ZToolPacket /*implements IRESPONSE_CALL
 
     final ImmutableMap<Integer, Class<? extends ZToolPacket>> clusterToRSP =
             ImmutableMap.<Integer, Class<? extends ZToolPacket>>builder()
+            .put(0x0013, ZDO_END_DEVICE_ANNCE_IND.class)
             .put(0x8000, ZDO_NWK_ADDR_RSP.class)
             .put(0x8001, ZDO_IEEE_ADDR_RSP.class)
             .put(0x8002, ZDO_NODE_DESC_RSP.class)

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_INCOMING.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_INCOMING.java
@@ -123,10 +123,8 @@ public class ZDO_MSG_CB_INCOMING extends ZToolPacket /*implements IRESPONSE_CALL
         Class<? extends ZToolPacket> newPacketClass = clusterToRSP.get(ClusterId.get16BitValue());
 
         if(newPacketClass == null) {
-            newPacket = new ZToolPacket();
-            newPacket.setError(true);
             logger.error("Unhandled ZDO cluster callback {}", ClusterId);
-            return newPacket;
+            return this;
         } else if (newPacketClass == ZDO_NWK_ADDR_RSP.class || newPacketClass == ZDO_IEEE_ADDR_RSP.class) {
             // The address responses don't need SrcAddr.  NumAssocDev and StartIndex positions are reversed.
 
@@ -153,9 +151,8 @@ public class ZDO_MSG_CB_INCOMING extends ZToolPacket /*implements IRESPONSE_CALL
         try {
             newPacket = (ZToolPacket) newPacketClass.getConstructor(int[].class).newInstance(frame);
         } catch (Exception e) {
-            newPacket = new ZToolPacket();
-            newPacket.setError(true);
             logger.error("Error constructing response packet {}", e);
+            return this;
         }
 
         // Set checksum with original packet checksum

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_INCOMING.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_INCOMING.java
@@ -1,0 +1,171 @@
+/*
+   Copyright 2008-2013 ITACA-TSB, http://www.tsb.upv.es/
+   Instituto Tecnologico de Aplicaciones de Comunicacion 
+   Avanzadas - Grupo Tecnologias para la Salud y el 
+   Bienestar (TSB)
+
+
+   See the NOTICE file distributed with this work for additional 
+   information regarding copyright ownership
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package org.bubblecloud.zigbee.network.packet.zdo;
+
+import java.util.Arrays;
+
+import org.bubblecloud.zigbee.network.packet.ZToolAddress16;
+import org.bubblecloud.zigbee.network.packet.ZToolCMD;
+import org.bubblecloud.zigbee.network.packet.ZToolPacket;
+import org.bubblecloud.zigbee.util.DoubleByte;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author <a href="mailto:ryan@presslab.us">Ryan Press</a>
+ * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2015-03-09 19:00:05 +0300 (Mon, 09 Mar 2015) $)
+ */
+public class ZDO_MSG_CB_INCOMING extends ZToolPacket /*implements IRESPONSE_CALLBACK,IZDO*/ {
+    private final static Logger logger = LoggerFactory.getLogger(ZDO_MSG_CB_INCOMING.class);
+
+    final ImmutableMap<Integer, Class<? extends ZToolPacket>> clusterToRSP =
+            ImmutableMap.<Integer, Class<? extends ZToolPacket>>builder()
+            .put(0x8000, ZDO_NWK_ADDR_RSP.class)
+            .put(0x8001, ZDO_IEEE_ADDR_RSP.class)
+            .put(0x8002, ZDO_NODE_DESC_RSP.class)
+            .put(0x8004, ZDO_SIMPLE_DESC_RSP.class)
+            .put(0x8005, ZDO_ACTIVE_EP_RSP.class)
+            .put(0x8006, ZDO_MATCH_DESC_RSP.class)
+            .put(0x8020, ZDO_END_DEVICE_BIND_RSP.class)
+            .put(0x8021, ZDO_BIND_RSP.class)
+            .put(0x8031, ZDO_MGMT_LQI_RSP.class)
+            .put(0x8034, ZDO_MGMT_LEAVE_RSP.class)
+            .put(0x8036, ZDO_MGMT_PERMIT_JOIN_RSP.class)
+            .build();
+    /* These clusters currently have no associated class
+            .put(0x8003, ZDO_POWER_DESC_RSP.class)
+            .put(0x8010, ZDO_COMPLEX_DESC_RSP.class)
+            .put(0x8011, ZDO_USER_DESC.class)
+            .put(0x8015, ZDO_SERVER_DISC_RSP.class)
+            .put(0x8022, ZDO_UNBIND.class)
+            .put(0x8030, ZDO_MGMT_NWK_DISC_RSP.class)
+            .put(0x8032, ZDO_MGMT_RTG_RSP.class)
+            .put(0x8033, ZDO_MGMT_BIND_RSP.class)
+            .put(0x8035, ZDO_MGMT_DIRECT_JOIN_RSP.class)
+     */
+
+    int FCS;
+
+    /// <name>TI.ZPI2.ZDO_MSG_CB_INCOMING.SrcAddr</name>
+    /// <summary>Short address (LSB-MSB) of the source of the ZDO message.</summary>
+    public ZToolAddress16 SrcAddr;
+    /// <name>TI.ZPI2.ZDO_MSG_CB_INCOMING.WasBroadcast</name>
+    /// <summary>This field indicates whether or not this ZDO message was broadcast.</summary>
+    public int WasBroadcast;
+    /// <name>TI.ZPI2.ZDO_MSG_CB_INCOMING.ClusterId</name>
+    /// <summary>The ZDO Cluster Id of this message.</summary>
+    public DoubleByte ClusterId;
+    /// <name>TI.ZPI2.ZDO_MSG_CB_INCOMING.SecurityUse</name>
+    /// <summary>N/A – not used.</summary>
+    public int SecurityUse;
+    /// <name>TI.ZPI2.ZDO_MSG_CB_INCOMING.SeqNum</name>
+    /// <summary>The sequence number of this ZDO message.</summary>
+    public int SeqNum;
+    /// <name>TI.ZPI2.ZDO_MSG_CB_INCOMING.MacDstAddr</name>
+    /// <summary>TThe MAC destination short address (LSB-MSB) of the ZDO message.</summary>
+    public ZToolAddress16 MacDstAddr;
+    /// <name>TI.ZPI2.ZDO_MSG_CB_INCOMING.Data</name>
+    /// <summary>The data that corresponds to the Cluster Id of the message.</summary>
+    public int[] Data;
+
+    /// <name>TI.ZPI2.ZDO_MSG_CB_INCOMING</name>
+    /// <summary>Constructor</summary>
+    public ZDO_MSG_CB_INCOMING() {
+    }
+
+    public ZDO_MSG_CB_INCOMING(int[] framedata) {
+        this.SrcAddr = new ZToolAddress16(framedata[1], framedata[0]);
+        this.WasBroadcast = framedata[2];
+        this.ClusterId = new DoubleByte(framedata[4], framedata[3]);
+        this.SecurityUse = framedata[5];
+        this.SeqNum = framedata[6];
+        this.MacDstAddr = new ZToolAddress16(framedata[8], framedata[7]);
+        this.Data = Arrays.copyOfRange(framedata, 9, framedata.length);
+
+        this.buildPacket(new DoubleByte(ZToolCMD.ZDO_MSG_CB_INCOMING), framedata);
+        this.FCS = getFCS();
+    }
+
+    /**
+     * Translates the ZigBee ZDO cluster packet into a ZTool RSP packet
+     *
+     * @param packet
+     */
+    public ZToolPacket translate() {
+        ZToolPacket newPacket;
+        int [] frame;
+
+        logger.trace("Translating ZDO cluster callback {}", ClusterId);
+
+        Class<? extends ZToolPacket> newPacketClass = clusterToRSP.get(ClusterId.get16BitValue());
+
+        if(newPacketClass == null) {
+            newPacket = new ZToolPacket();
+            newPacket.setError(true);
+            logger.error("Unhandled ZDO cluster callback {}", ClusterId);
+            return newPacket;
+        } else if (newPacketClass == ZDO_NWK_ADDR_RSP.class || newPacketClass == ZDO_IEEE_ADDR_RSP.class) {
+            // The address responses don't need SrcAddr.  NumAssocDev and StartIndex positions are reversed.
+
+            // The new response frame is at least 13 bytes long.
+            frame = new int[Math.max(Data.length, 13)];
+            System.arraycopy(Data, 0, frame, 0, Data.length);
+            // If RequestType == 1 there are two extra bytes in the frame
+            if (Data.length > 12) {
+                frame[11] = Data[12]; // NumAssocDev
+                frame[12] = Data[11]; // StartIndex
+            } else {
+                frame[11] = 0;
+                frame[12] = 0;
+            }
+        } else {
+            // Default frame translation, this works for most callbacks.
+            //  Get 2 extra bytes at the beginning to put source address into.
+            frame = new int[Data.length + 2];
+            System.arraycopy(Data,  0,  frame,  2,  Data.length);
+            frame[0] = SrcAddr.getLsb();
+            frame[1] = SrcAddr.getMsb();
+        }
+
+        try {
+            newPacket = (ZToolPacket) newPacketClass.getConstructor(int[].class).newInstance(frame);
+        } catch (Exception e) {
+            newPacket = new ZToolPacket();
+            newPacket.setError(true);
+            logger.error("Error constructing response packet {}", e);
+        }
+
+        // Set checksum with original packet checksum
+        newPacket.setFCS(this.FCS);
+
+        return newPacket;
+    }
+
+    @Override
+    public String toString() {
+        return "ZDO_MSG_CB_INCOMING{" + "ClusterId=" + ClusterId + '}';
+    }
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_REGISTER.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_REGISTER.java
@@ -1,0 +1,41 @@
+/*
+   Copyright 2008-2013 ITACA-TSB, http://www.tsb.upv.es/
+   Instituto Tecnologico de Aplicaciones de Comunicacion 
+   Avanzadas - Grupo Tecnologias para la Salud y el 
+   Bienestar (TSB)
+
+
+   See the NOTICE file distributed with this work for additional 
+   information regarding copyright ownership
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package org.bubblecloud.zigbee.network.packet.zdo;
+
+import org.bubblecloud.zigbee.network.packet.ZToolCMD;
+import org.bubblecloud.zigbee.network.packet.ZToolPacket;
+import org.bubblecloud.zigbee.util.DoubleByte;
+
+/**
+ * @author <a href="mailto:ryan@presslab.us">Ryan Press</a>
+ * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2015-03-09 19:00:05 +0300 (Mon, 09 Mar 2015) $)
+ */
+public class ZDO_MSG_CB_REGISTER extends ZToolPacket /*implements IREQUEST,IZDO*/ {
+    public ZDO_MSG_CB_REGISTER(DoubleByte cluster) {
+        int[] framedata = new int[2];
+        framedata[0] = cluster.getLsb();
+        framedata[1] = cluster.getMsb();
+        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_MSG_CB_REGISTER), framedata);
+    }
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_REGISTER_SRSP.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_REGISTER_SRSP.java
@@ -1,0 +1,55 @@
+/*
+   Copyright 2008-2013 ITACA-TSB, http://www.tsb.upv.es/
+   Instituto Tecnologico de Aplicaciones de Comunicacion 
+   Avanzadas - Grupo Tecnologias para la Salud y el 
+   Bienestar (TSB)
+
+
+   See the NOTICE file distributed with this work for additional 
+   information regarding copyright ownership
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package org.bubblecloud.zigbee.network.packet.zdo;
+
+import org.bubblecloud.zigbee.network.packet.ResponseStatus;
+import org.bubblecloud.zigbee.network.packet.ZToolCMD;
+import org.bubblecloud.zigbee.network.packet.ZToolPacket;
+import org.bubblecloud.zigbee.util.DoubleByte;
+
+/**
+ * @author <a href="mailto:ryan@presslab.us">Ryan Press</a>
+ * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2015-03-09 19:00:05 +0300 (Mon, 09 Mar 2015) $)
+ */
+public class ZDO_MSG_CB_REGISTER_SRSP extends ZToolPacket /*implements IRESPONSE_CALLBACK,IZDO*/ {
+    /// <name>TI.ZPI2.ZDO_MSG_CB_REGISTER_SRSP.Status</name>
+    /// <summary>this field indicates either SUCCESS or FAILURE.</summary>
+    public int Status;
+    /// <name>TI.ZPI2.ZDO_MSG_CB_REGISTER_SRSP</name>
+    /// <summary>Constructor</summary>
+    public ZDO_MSG_CB_REGISTER_SRSP() {
+    }
+
+    public ZDO_MSG_CB_REGISTER_SRSP(int[] framedata) {
+        this.Status = framedata[0];
+        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_MSG_CB_REGISTER_SRSP), framedata);
+    }
+
+    @Override
+    public String toString() {
+        return "ZDO_MSG_CB_REGISTER_SRSP{" +
+                "Status=" + ResponseStatus.getStatus(Status) +
+                '}';
+    }
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_TC_DEVICE_IND.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_TC_DEVICE_IND.java
@@ -1,0 +1,65 @@
+/*
+   Copyright 2008-2013 ITACA-TSB, http://www.tsb.upv.es/
+   Instituto Tecnologico de Aplicaciones de Comunicacion 
+   Avanzadas - Grupo Tecnologias para la Salud y el 
+   Bienestar (TSB)
+
+
+   See the NOTICE file distributed with this work for additional 
+   information regarding copyright ownership
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package org.bubblecloud.zigbee.network.packet.zdo;
+
+import org.bubblecloud.zigbee.network.packet.ZToolAddress16;
+import org.bubblecloud.zigbee.network.packet.ZToolAddress64;
+import org.bubblecloud.zigbee.network.packet.ZToolCMD;
+import org.bubblecloud.zigbee.network.packet.ZToolPacket;
+import org.bubblecloud.zigbee.util.DoubleByte;
+
+/**
+ * @author <a href="mailto:ryan@presslab.us">Ryan Press</a>
+ * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2015-03-15 19:00:05 +0300 (Sun, 15 Mar 2015) $)
+ */
+public class ZDO_TC_DEVICE_IND extends ZToolPacket /*implements IRESPONSE_CALLBACK,IZDO*/ {
+    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND.IEEEAddr</name>
+    /// <summary>64 bit IEEE address of source device</summary>
+    public ZToolAddress64 IEEEAddr;
+    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND.NwkAddr</name>
+    /// <summary>Network address</summary>
+    public ZToolAddress16 NwkAddr;
+    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND.SrcAddr</name>
+    /// <summary>Source address</summary>
+    public ZToolAddress16 SrcAddr;
+
+    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND</name>
+    /// <summary>Constructor</summary>
+    public ZDO_TC_DEVICE_IND() {
+    }
+
+    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND</name>
+    /// <summary>Constructor</summary>
+    public ZDO_TC_DEVICE_IND(int[] framedata) {
+        this.SrcAddr = new ZToolAddress16(framedata[1], framedata[0]);
+        byte[] bytes = new byte[8];
+        for (int i = 0; i < 8; i++) {
+            bytes[i] = (byte) framedata[9 - i];
+        }
+        this.IEEEAddr = new ZToolAddress64(bytes);
+        this.NwkAddr = new ZToolAddress16(framedata[11], framedata[10]);
+        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_TC_DEVICE_IND), framedata);
+    }
+
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -183,6 +183,11 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
             logger.error("Failed to initialize the dongle on port {}.", port);
             return false;
         }
+        if (!dongleReset()) {
+            logger.error("Unable to reset dongle");
+            return false;
+        }
+
         return true;
     }
 
@@ -842,8 +847,6 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     private boolean dongleReset() {
-        if (waitForHardware() == false) return false;
-
         final WaitForCommand waiter = new WaitForCommand(
                 ZToolCMD.SYS_RESET_RESPONSE,
 				zigbeeInterface

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -30,9 +30,9 @@ import org.bubblecloud.zigbee.network.packet.system.SYS_RESET_RESPONSE;
 import org.bubblecloud.zigbee.network.packet.util.UTIL_GET_DEVICE_INFO;
 import org.bubblecloud.zigbee.network.packet.util.UTIL_GET_DEVICE_INFO_RESPONSE;
 import org.bubblecloud.zigbee.network.packet.zdo.*;
+import org.bubblecloud.zigbee.util.DoubleByte;
 import org.bubblecloud.zigbee.util.Integers;
 import org.bubblecloud.zigbee.network.model.*;
-import org.bubblecloud.zigbee.util.NetworkAddressUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -217,6 +217,15 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
             case EndDevice:
                 logger.debug("Creating network as end device.");
             break;
+        }
+        final int ALL_CLUSTERS = 0xFFFF;
+
+        logger.trace("Reset seq: Trying MSG_CB_REGISTER");
+        ZDO_MSG_CB_REGISTER_SRSP responseCb = (ZDO_MSG_CB_REGISTER_SRSP) sendSynchrouns(
+				zigbeeInterface, new ZDO_MSG_CB_REGISTER(new DoubleByte(ALL_CLUSTERS))
+        );
+        if (responseCb == null) {
+            logger.warn("Reset seq: Failed MSG_CB_REGISTER");
         }
 
         final int INSTANT_STARTUP = 0;
@@ -963,7 +972,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
 
     private ZToolPacket sendSynchrouns(final ZigBeeInterface hwDriver, final ZToolPacket request) {
         final ZToolPacket[] response = new ZToolPacket[]{null};
-//		final int TIMEOUT = 1000, MAX_SEND = 3;
+//		final int RESEND_TIMEOUT = 1000, RESEND_MAX_RETRY = 3;
         int sending = 1;
 
         logger.trace("{} sending as synchronous command.", request.getClass().getSimpleName());

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -1472,6 +1472,13 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
                     l.announce(annunce.SrcAddr, annunce.IEEEAddr, annunce.NwkAddr, annunce.Capabilities);
 
                 }
+            } else if (packet.getCMD().get16BitValue() == ZToolCMD.ZDO_TC_DEVICE_IND) {
+                    logger.debug("Recieved TC announce message {} value is {}", packet.getClass(), packet);
+                    ZDO_TC_DEVICE_IND annunce = (ZDO_TC_DEVICE_IND) packet;
+                    for (AnnounceListener l : listners) {
+                        l.announce(annunce.SrcAddr, annunce.IEEEAddr, annunce.NwkAddr, 0);
+
+                    }
             } else if (packet.getCMD().get16BitValue() == ZToolCMD.ZDO_STATE_CHANGE_IND) {
                 try {
                     ZDO_STATE_CHANGE_IND p = ((ZDO_STATE_CHANGE_IND) packet);


### PR DESCRIPTION
The new versions of Z-Stack firmware do not work with zigbee4java.  This is because the firmware does not support the ZDO_xxx_RSP commands.  This code translates from the ZDO_MSG_CB_INCOMING command to the ZDO_xxx_RSP commands.  It also fixes a few other problems that were exposed when using the new firmware.

Tested with the Z-Stack 2.6.2 ZNP firmware `CC2531ZNP-Pro-Secure_Standard.hex` that is bundled with Z-Stack Home 1.2.2.  Support for the older firmware remains.