### PR TITLE
Console join command

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/AttributeImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/AttributeImpl.java
@@ -152,7 +152,7 @@ public class AttributeImpl implements Attribute {
                     } else {
                         Status state = Status.getStatus(attributeStatus.getStatus());
                         throw new ZigBeeClusterException(
-                                "Read Attribute of " + getName() + " (" + getId() + " ) failed." +
+                                "Read Attribute '" + getName() + "' (" + getId() + ") failed." +
                                         "Due to " + state + " that means " + state.description
                         );
                     }
@@ -161,19 +161,19 @@ public class AttributeImpl implements Attribute {
                     final DefaultResponse result = new DefaultResponseImpl(response);
                     Status state = result.getStatus();
                     throw new ZigBeeClusterException(
-                            "Read Attribute of " + getId() + " failed because command is not supported."
+                            "Read Attribute " + getId() + " failed because command is not supported."
                                     + "Due to " + state + " that means " + state.description
                                     + " Follows the ZCLFrame recieved " + ResponseImpl.toString(response)
                     );
 
                 default:
                     throw new ZigBeeClusterException(
-                            "Read Attribute of " + getId() + " failed due to: Unsupported answer: " + response
+                            "Read Attribute " + getId() + " failed due to: Unsupported answer: " + response
                                     + " Follows the ZCLFrame recieved " + ResponseImpl.toString(response)
                     );
             }
         } catch (ZigBeeNetworkManagerException e) {
-            throw new ZigBeeClusterException("Read Attribute of " + getId() + " failed due to:  " + e);
+            throw new ZigBeeClusterException("Read Attribute " + getId() + " failed due to:  " + e);
         }
     }
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
@@ -197,7 +197,7 @@ public class EndpointBuilder implements Stoppable {
             } else {
                 // if you don't remove node with devices not yet inspected from network, you won't be able to re-inspect them later
                 // maybe device is sleeping and you have to wait for a non-sleeping period
-                logger.debug("Node {} removed from network because attempts to instantiate devices on it are failed", node);
+                logger.debug("Node {} removed from network because attempts to instantiate devices on it have failed", node);
                 network.removeNode(node);
             }
         } else {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/LinkQualityIndicatorNetworkBrowser.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/LinkQualityIndicatorNetworkBrowser.java
@@ -158,8 +158,8 @@ public class LinkQualityIndicatorNetworkBrowser extends RunnableThread {
                 return null;
             } else {
                 logger.debug(
-                        "Found {} neighbors on node {}",
-                        lqi_resp.getNeighborLQICount(), node.address);
+                        "Found {} neighbors on node #{}",
+                        lqi_resp.getNeighborLQICount(), nwk16.get16BitValue());
 
                 NeighborLqiListItemClass[] neighbors = (NeighborLqiListItemClass[]) lqi_resp.getNeighborLqiList();
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -1483,14 +1483,14 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
         public void receivedAsynchronousCommand(ZToolPacket packet) {
             if (packet.isError()) return;
             if (packet.getCMD().get16BitValue() == ZToolCMD.ZDO_END_DEVICE_ANNCE_IND) {
-                logger.debug("Recieved announce message {} value is {}", packet.getClass(), packet);
+                logger.debug("Received announce message {} value is {}", packet.getClass(), packet);
                 ZDO_END_DEVICE_ANNCE_IND annunce = (ZDO_END_DEVICE_ANNCE_IND) packet;
                 for (AnnounceListener l : listners) {
                     l.announce(annunce.SrcAddr, annunce.IEEEAddr, annunce.NwkAddr, annunce.Capabilities);
 
                 }
             } else if (packet.getCMD().get16BitValue() == ZToolCMD.ZDO_TC_DEVICE_IND) {
-                    logger.debug("Recieved TC announce message {} value is {}", packet.getClass(), packet);
+                    logger.debug("Received TC announce message {} value is {}", packet.getClass(), packet);
                     ZDO_TC_DEVICE_IND annunce = (ZDO_TC_DEVICE_IND) packet;
                     for (AnnounceListener l : listners) {
                         l.announce(annunce.SrcAddr, annunce.IEEEAddr, annunce.NwkAddr, 0);

--- a/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -109,7 +109,6 @@ public final class ZigBeeConsole {
         /* TODO Use something like a command line parameter to decide if permit join is re-enabled */
         if (!zigbeeApi.permitJoin(true)) {
             print("ZigBee API permit join enable ... [FAIL]");
-            return;
         } else {
             print("ZigBee API permit join enable ... [OK]");
         }
@@ -122,6 +121,7 @@ public final class ZigBeeConsole {
 
             @Override
             public void deviceUpdated(Device device) {
+                print("Device updated: " + device.getEndpointId() + " (#" + device.getNetworkAddress() + ")");
             }
 
             @Override

--- a/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -75,6 +75,7 @@ public final class ZigBeeConsole {
 		commands.put("unsubscribe", new UnsubscribeCommand());
 		commands.put("read", 		new ReadCommand());
 		commands.put("write", 		new WriteCommand());
+		commands.put("join",        new JoinCommand());
 	}
 
 	/**
@@ -1185,6 +1186,41 @@ public final class ZigBeeConsole {
         }
     }
 
+    private class JoinCommand implements ConsoleCommand {
+        /**
+         * {@inheritDoc}
+         */
+        public String getDescription() {
+            return "Enable or diable network join.";
+        }
+        /**
+         * {@inheritDoc}
+         */
+        public String getSyntax() {
+            return "join [en|dis]";
+        }
+        /**
+         * {@inheritDoc}
+         */
+        public boolean process(final ZigBeeApi zigbeeApi, final String[] args) {
+            if (args.length != 2) {
+                return false;
+            }
+            
+            boolean join = false;
+            if(args[1].toLowerCase().startsWith("e")) {
+            	join = true;
+            }
+
+            if (!zigbeeApi.permitJoin(join)) {
+                print("ZigBee API permit join enable ... [FAIL]");
+            } else {
+                print("ZigBee API permit join enable ... [OK]");
+            }
+            return true;
+        }
+    }
+    
     /**
      * Anonymous class report listener implementation which prints the reports to console.
      */


### PR DESCRIPTION
This adds a 'join' command to the console to enable or disable join. It also fixes a few typos in log messages and one or two negative numbers printed as network addresses.

I also removed the 'return' if the join fails on startup. When using the old firmware I found this fails, and it doesn't seem to me that it should stop the stack working all together so I think it should print the message and continue.