### PR TITLE
Change end of stream check to -1

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketParser.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketParser.java
@@ -115,9 +115,9 @@ public class ZToolPacketParser implements Runnable {
 
                     packetHandler.handlePacket(response);
                 } else {
-                    if (val != 0) {
-                        // Log if not end of stream signaling zero byte.
-                        logger.warn("Discared stream: expected start byte but received this {}",
+                    if (val != -1) {
+                        // Log if not end of stream.
+                        logger.warn("Discarded stream: expected start byte but received this {}",
                                 ByteUtils.toBase16(val));
                     }
                 }

--- a/zigbee-console-javase/src/main/java/org/bubblecloud/zigbee/ZigBeeConsoleJavaSE.java
+++ b/zigbee-console-javase/src/main/java/org/bubblecloud/zigbee/ZigBeeConsoleJavaSE.java
@@ -8,7 +8,7 @@ import org.bubblecloud.zigbee.network.port.ZigBeeSerialPortImpl;
  */
 public class ZigBeeConsoleJavaSE
 {
-	private static final int DefaultBaudRate = 38400;
+	private static final int DefaultBaudRate = 115200;
 
 	private ZigBeeConsoleJavaSE(){}
 


### PR DESCRIPTION
The doc for inputStream.read() states -:
>The value byte is returned as an int in the range 0 to 255. If no byte is available because the end of the stream has been reached, the value -1 is returned.

