### PR TITLE
Add separate RESET_TIMEOUT to account for long delay in CC2531 board startup

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketParser.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketParser.java
@@ -100,7 +100,6 @@ public class ZToolPacketParser implements Runnable {
         while (!close) {
             try {
                 int val = inputStream.read();
-                logger.trace("Read {} from input stream ", ByteUtils.formatByte(val));
                 if (val == ZToolPacket.START_BYTE) {
                     inputStream.mark(256);
                     final ZToolPacketStream packetStream = new ZToolPacketStream(inputStream);
@@ -114,12 +113,10 @@ public class ZToolPacketParser implements Runnable {
                     }
 
                     packetHandler.handlePacket(response);
-                } else {
-                    if (val != -1) {
-                        // Log if not end of stream.
-                        logger.warn("Discarded stream: expected start byte but received this {}",
-                                ByteUtils.toBase16(val));
-                    }
+                } else if (val != -1) {
+                    // Log if not end of stream.
+                    logger.warn("Discarded stream: expected start byte but received this {}",
+                            ByteUtils.toBase16(val));
                 }
             } catch (final IOException e) {
                 if (!close) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -59,6 +59,9 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     public static final int DEFAULT_TIMEOUT = 5000;
     public static final String TIMEOUT_KEY = "zigbee.driver.cc2530.timeout";
 
+    public static final int RESET_TIMEOUT_DEFAULT = 60000;
+    public static final String RESET_TIMEOUT_KEY = "zigbee.driver.cc2530.reset.timeout";
+
     public static final int STARTUP_TIMEOUT_DEFAULT = 5000;
     public static final String STARTUP_TIMEOUT_KEY = "zigbee.driver.cc2530.startup.timeout";
 
@@ -72,6 +75,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     public static final String RESEND_ONLY_EXCEPTION_KEY = "zigbee.driver.cc2530.resend.exceptionally";
 
     private final int TIMEOUT;
+    private final int RESET_TIMEOUT;
     private final int STARTUP_TIMEOUT;
     private final int RESEND_TIMEOUT;
     private final int RESEND_MAX_RETRY;
@@ -114,6 +118,15 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
             logger.trace("Using TIMEOUT set as DEFAULT {}ms", aux);
         }
         TIMEOUT = aux;
+
+        aux = (int) Math.max(RESET_TIMEOUT_DEFAULT, timeout);
+        try {
+            aux = Integer.parseInt(System.getProperty(RESET_TIMEOUT_KEY));
+            logger.trace("Using RESET_TIMEOUT set from enviroment {}", aux);
+        } catch (NumberFormatException ex) {
+            logger.trace("Using RESET_TIMEOUT set as DEFAULT {}ms", aux);
+        }
+        RESET_TIMEOUT = aux;
 
         aux = (int) Math.max(STARTUP_TIMEOUT_DEFAULT, timeout);
         try {
@@ -872,7 +885,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
         }
 
         SYS_RESET_RESPONSE response =
-                (SYS_RESET_RESPONSE) waiter.getCommand(TIMEOUT);
+                (SYS_RESET_RESPONSE) waiter.getCommand(RESET_TIMEOUT);
 
         return response != null;
     }

--- a/zigbee-serial-javase/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeSerialPortImpl.java
+++ b/zigbee-serial-javase/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeSerialPortImpl.java
@@ -87,7 +87,7 @@ public class ZigBeeSerialPortImpl implements ZigBeePort
         }
 
         serialPort = portMap.get(port);
-        logger.debug("Opening portIdentifier portIdentifier '" + serialPort.getSystemPortName() + "'.");
+        logger.debug("Opening portIdentifier '" + serialPort.getSystemPortName() + "'.");
         if (!serialPort.openPort()) {
             throw new RuntimeException("Serial portIdentifier '" + port + "' startup failed.");
         }


### PR DESCRIPTION
As per https://github.com/tlaukkan/zigbee4java/issues/37 the CC2531 dongles appear to wait for up to 1 minute after powerup before they will respond to a reset. This PR adds a separate timeout which is used during the reset interval and is defaulted to 60 seconds.
