### PR TITLE
Startup refactor

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNetworkManager.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNetworkManager.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
  * @author <a href="mailto:stefano.lenzi@isti.cnr.it">Stefano "Kismet" Lenzi - ISTI-CNR</a>
  * @author <a href="mailto:manlio.bacco@isti.cnr.it">Manlio Bacco - ISTI-CNR</a>
  * @author <a href="mailto:christopherhattonuk@gmail.com">Chris Hatton</a>
+ * @author <a href="mailto:chris@cd-jackson.com>Chris Jackson</a>
  * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)
  * @since 0.1.0
  */
@@ -48,7 +49,7 @@ public interface ZigBeeNetworkManager {
 
     public abstract void setPort(ZigBeePort port);
 
-    public abstract void startup();
+    public abstract boolean startup();
 
     public abstract void shutdown();
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/model/DriverStatus.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/model/DriverStatus.java
@@ -36,6 +36,12 @@ public enum DriverStatus {
     CREATED,
 
     /**
+     * The driver has opened the hardware resources, and it is waiting for<br>
+     * the hardware to complete the reset process
+     */
+    HARDWARE_OPEN,
+
+    /**
      * The driver has already initialized all the hardware resources, and it is waiting for<br>
      * the hardware to complete the initialization process
      */

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketParser.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketParser.java
@@ -100,7 +100,6 @@ public class ZToolPacketParser implements Runnable {
         while (!close) {
             try {
                 int val = inputStream.read();
-                logger.trace("Read {} from input stream ", ByteUtils.formatByte(val));
                 if (val == ZToolPacket.START_BYTE) {
                     inputStream.mark(256);
                     final ZToolPacketStream packetStream = new ZToolPacketStream(inputStream);
@@ -114,12 +113,10 @@ public class ZToolPacketParser implements Runnable {
                     }
 
                     packetHandler.handlePacket(response);
-                } else {
-                    if (val != -1) {
-                        // Log if not end of stream.
-                        logger.warn("Discarded stream: expected start byte but received this {}",
-                                ByteUtils.toBase16(val));
-                    }
+                } else if (val != -1) {
+                    // Log if not end of stream.
+                    logger.warn("Discarded stream: expected start byte but received this {}",
+                            ByteUtils.toBase16(val));
                 }
             } catch (final IOException e) {
                 if (!close) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -60,6 +60,9 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     public static final int DEFAULT_TIMEOUT = 5000;
     public static final String TIMEOUT_KEY = "zigbee.driver.cc2530.timeout";
 
+    public static final int RESET_TIMEOUT_DEFAULT = 60000;
+    public static final String RESET_TIMEOUT_KEY = "zigbee.driver.cc2530.reset.timeout";
+
     public static final int STARTUP_TIMEOUT_DEFAULT = 5000;
     public static final String STARTUP_TIMEOUT_KEY = "zigbee.driver.cc2530.startup.timeout";
 
@@ -73,6 +76,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     public static final String RESEND_ONLY_EXCEPTION_KEY = "zigbee.driver.cc2530.resend.exceptionally";
 
     private final int TIMEOUT;
+    private final int RESET_TIMEOUT;
     private final int STARTUP_TIMEOUT;
     private final int RESEND_TIMEOUT;
     private final int RESEND_MAX_RETRY;
@@ -113,6 +117,15 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
             logger.trace("Using TIMEOUT set as DEFAULT {}ms", aux);
         }
         TIMEOUT = aux;
+
+        aux = (int) Math.max(RESET_TIMEOUT_DEFAULT, timeout);
+        try {
+            aux = Integer.parseInt(System.getProperty(RESET_TIMEOUT_KEY));
+            logger.trace("Using RESET_TIMEOUT set from enviroment {}", aux);
+        } catch (NumberFormatException ex) {
+            logger.trace("Using RESET_TIMEOUT set as DEFAULT {}ms", aux);
+        }
+        RESET_TIMEOUT = aux;
 
         aux = (int) Math.max(STARTUP_TIMEOUT_DEFAULT, timeout);
         try {
@@ -886,7 +899,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
         }
 
         SYS_RESET_RESPONSE response =
-                (SYS_RESET_RESPONSE) waiter.getCommand(TIMEOUT);
+                (SYS_RESET_RESPONSE) waiter.getCommand(RESET_TIMEOUT);
 
         return response != null;
     }

--- a/zigbee-api/src/test/java/org/bubblecloud/zigbee/ZigBeeNetworkTest.java
+++ b/zigbee-api/src/test/java/org/bubblecloud/zigbee/ZigBeeNetworkTest.java
@@ -36,8 +36,7 @@ public abstract class ZigBeeNetworkTest {
     public void testOpenNetwork() throws Exception {
 
         final ZigBeeNetworkManagerImpl zigbeeNetwork = new ZigBeeNetworkManagerImpl(
-                port, NetworkMode.Coordinator, 4951, 22,
-                false, 2500L);
+                port, NetworkMode.Coordinator, 4951, 22, 2500L);
         zigbeeNetwork.startup();
 
         while (true) {
@@ -55,8 +54,7 @@ public abstract class ZigBeeNetworkTest {
     public void testDiscoverNetwork() throws Exception {
 
         final ZigBeeNetworkManagerImpl zigbeeNetworkManager = new ZigBeeNetworkManagerImpl(
-                port, NetworkMode.Coordinator, 4951, 22,
-                false, 2500L);
+                port, NetworkMode.Coordinator, 4951, 22, 2500L);
 
         final ZigBeeDiscoveryManager zigbeeDiscoveryManager = new ZigBeeDiscoveryManager(zigbeeNetworkManager, DiscoveryMode.ALL);
         zigbeeDiscoveryManager.startup();

--- a/zigbee-serial-javase/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeSerialPortImpl.java
+++ b/zigbee-serial-javase/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeSerialPortImpl.java
@@ -87,7 +87,7 @@ public class ZigBeeSerialPortImpl implements ZigBeePort
         }
 
         serialPort = portMap.get(port);
-        logger.debug("Opening portIdentifier portIdentifier '" + serialPort.getSystemPortName() + "'.");
+        logger.debug("Opening portIdentifier '" + serialPort.getSystemPortName() + "'.");
         if (!serialPort.openPort()) {
             throw new RuntimeException("Serial portIdentifier '" + port + "' startup failed.");
         }


### PR DESCRIPTION
This changes the startup methods to allow for the system to read the dongle configuration before the network starts. This allows the system to detect if the dongle configuration is different to that asked for, and then do a reset of the dongle - this is not possible in the current methods as the reset flag is included in the constructor...

You can still use the current _startup_ method which works the same as normal. However, it also adds _initializeHardware_ and _initializeNetwork_ methods which effectively splits _startup_ method in two.

After calling _initializeHardware_ you can then call the _getCurrentChannel_ and _getCurrentPanId_ methods, and then the _initializeNetwork_ method. The _initializeHardware_ method takes parameter to specify if the network should be reset or not.

This also fixes a bug during the startup. If the startup sequence fails in the _.open()_ method due to the reset timing out, then _.close()_ doesn't get called.

I might merge my other dongle reset PR into this but it would be good if @tlaukkan and @chris-hatton can comment on this before it's merged. It shouldn't break anything as the existing methods are retained, but is a bit of a change all the same.