### PR TITLE
Send magic number on dongle start to break out of the boot loader

### DIFF
--- a/zigbee-serial-javase/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeSerialPortImpl.java
+++ b/zigbee-serial-javase/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeSerialPortImpl.java
@@ -47,6 +47,11 @@ public class ZigBeeSerialPortImpl implements ZigBeePort
         try {
             openSerialPort(portIdentifier, 0, baudRate, 8, SerialComm.ONE_STOP_BIT,
                     SerialComm.NO_PARITY, SerialComm.FLOW_CONTROL_DISABLED);
+            
+            // Write the 'magic byte'
+            // Note that this might change in future, or with different dongles
+            outputStream.write(0xef);
+
             return true;
         } catch (Exception e) {
             logger.error("Error...", e);


### PR DESCRIPTION
This sends the magic number for the TI CC2531 bootloader
I've put this into the port driver so it can be changed easier for each implementation...
#37 