### PR TITLE
Node/service discovery improvements

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeApi.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeApi.java
@@ -17,6 +17,7 @@ package org.bubblecloud.zigbee;
 
 import org.bubblecloud.zigbee.network.EndpointListener;
 import org.bubblecloud.zigbee.network.ZigBeeEndpoint;
+import org.bubblecloud.zigbee.network.ZigBeeNode;
 import org.bubblecloud.zigbee.network.discovery.ZigBeeDiscoveryManager;
 import org.bubblecloud.zigbee.network.impl.NetworkStateSerializer;
 import org.bubblecloud.zigbee.network.impl.ZigBeeNetwork;
@@ -52,6 +53,7 @@ import java.util.*;
  * ZigBee Application Interface.
  * @author <a href="mailto:tommi.s.e.laukkanen@gmail.com">Tommi S.E. Laukkanen</a>
  * @author <a href="mailto:christopherhattonuk@gmail.com">Chris Hatton</a>
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
  */
 public class ZigBeeApi implements EndpointListener, DeviceListener {
     /**
@@ -352,6 +354,15 @@ public class ZigBeeApi implements EndpointListener, DeviceListener {
 
     public List<Device> getDevices() {
         return context.getDevices();
+    }
+
+    public List<ZigBeeNode> getNodes() {
+    	ArrayList<ZigBeeNode> nodes = new ArrayList<ZigBeeNode>();
+        for(ZigBeeNode n : network.getNodes().values()) {
+        	nodes.add(n);
+        }
+
+        return nodes;
     }
 
     public void addDeviceListener(DeviceListener deviceListener) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/DeviceBase.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/DeviceBase.java
@@ -136,8 +136,8 @@ public abstract class DeviceBase implements Device {
     protected Cluster addCluster(int clusterId) throws ZigBeeDeviceException {
         /*
          * Verify if the cluster has already been added. For example, when the HA Driver is working with
-         * ProvidedClusterMode.EitherInputAndOutput mode the HA Driver adds either inputs and outputs cluster
-         * to the DeviceBase
+         * ProvidedClusterMode.EitherInputAndOutput mode the HA Driver adds either inputs and outputs
+         * cluster to the DeviceBase
          */
         final Cluster duplicated = getCluster(clusterId);
         if (duplicated != null) {
@@ -152,7 +152,8 @@ public abstract class DeviceBase implements Device {
 
         //TODO We should move this code in isClusterValid() method
         /*
-         * We are trying to add a cluster which is not defined as input cluster and is optional then we are not going to add it
+         * We are trying to add a cluster which is not defined as input cluster and is
+         * optional then we are not going to add it
          */
         if (!endpoint.providesInputCluster(clusterId) && getDescription().isOptional(clusterId)) {
             logger.warn(
@@ -166,7 +167,8 @@ public abstract class DeviceBase implements Device {
         }
 
         /*
-         * We are trying to add a cluster which is not defined as input cluster and is optional then we are not going to add it
+         * We are trying to add a cluster which is not defined as input cluster and is
+         * optional then we are not going to add it
          */
         if (!endpoint.providesInputCluster(clusterId) && getDescription().isCustom(clusterId)) {
             //TODO check if exists custom add-on by using ProfileModule interface
@@ -179,8 +181,10 @@ public abstract class DeviceBase implements Device {
         }
 
         /*
-         * This is the last case, when a Cluster is not defined as input but it is among the mandotory cluster of the device
-         * so if ProvidedClusterMode.EitherInputAndOutput is set we will consider it as a firmware issue so we will add the cluster anyway
+         * This is the last case, when a Cluster is not defined as input but
+         * it is among the mandatory cluster of the device.
+         * So if ProvidedClusterMode.EitherInputAndOutput is set we will consider
+         * it as a firmware issue so we will add the cluster anyway
          */
         if (!endpoint.providesInputCluster(clusterId) && getDescription().isMandatory(clusterId)) {
             logger.warn(

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNetworkManager.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNetworkManager.java
@@ -57,6 +57,8 @@ public interface ZigBeeNetworkManager {
 
     public abstract ZDO_NODE_DESC_RSP sendZDONodeDescriptionRequest(ZDO_NODE_DESC_REQ request);
 
+    public abstract ZDO_POWER_DESC_RSP sendZDOPowerDescriptionRequest(ZDO_POWER_DESC_REQ request);
+
     public abstract ZDO_ACTIVE_EP_RSP sendZDOActiveEndPointRequest(ZDO_ACTIVE_EP_REQ request);
 
     public abstract ZDO_SIMPLE_DESC_RSP sendZDOSimpleDescriptionRequest(ZDO_SIMPLE_DESC_REQ request);

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNode.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNode.java
@@ -50,4 +50,9 @@ public interface ZigBeeNode {
      */
     public String getIeeeAddress();
 
+    public void setNodeDescriptor(ZigBeeNodeDescriptor descriptor);
+    public ZigBeeNodeDescriptor getNodeDescriptor();
+
+    public void setPowerDescriptor(ZigBeeNodePowerDescriptor descriptor);
+    public ZigBeeNodePowerDescriptor getPowerDescriptor();
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNode.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNode.java
@@ -24,15 +24,18 @@ package org.bubblecloud.zigbee.network;
 
 
 /**
- * This class represent a ZigBee node, it means a physical device that can communicate<br>
- * using the ZigBee protocol.<br>
- * Each physical may contain up 240 endpoints which are represented by the {@link ZigBeeEndpoint}<br>
- * class. Each endpoint is identified by an <i>EndPoint</i> address, but shares iether the:<br>
+ * This class represent a ZigBee node, it means a physical device that can communicate
+ * using the ZigBee protocol.
+ * <p>
+ * Each physical may contain up 240 endpoints which are represented by the {@link ZigBeeEndpoint}
+ * class. Each endpoint is identified by an <i>EndPoint</i> address, but shares either the:<br>
  * - <i>64-bit 802.15.4 IEEE Address</i><br>
  * - <i>16-bit ZigBee Network Address</i><br>
+ * <p>
  *
  * @author <a href="mailto:stefano.lenzi@isti.cnr.it">Stefano "Kismet" Lenzi</a>
  * @author <a href="mailto:francesco.furfari@isti.cnr.it">Francesco Furfari</a>
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
  * @since 0.1.0
  */
 public interface ZigBeeNode {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNode.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNode.java
@@ -32,6 +32,10 @@ package org.bubblecloud.zigbee.network;
  * - <i>64-bit 802.15.4 IEEE Address</i><br>
  * - <i>16-bit ZigBee Network Address</i><br>
  * <p>
+ * The node descriptors are also available through the node. These provide basic information
+ * about the device itself and are only available in the node (ie they are the same for all
+ * endpoints).
+ * <p>
  *
  * @author <a href="mailto:stefano.lenzi@isti.cnr.it">Stefano "Kismet" Lenzi</a>
  * @author <a href="mailto:francesco.furfari@isti.cnr.it">Francesco Furfari</a>
@@ -50,9 +54,37 @@ public interface ZigBeeNode {
      */
     public String getIeeeAddress();
 
+    /**
+     * Sets the {@link ZigBeeNodeDescriptor Node Descriptor}.
+     * <p>
+     * The node descriptor contains information about the capabilities of the ZigBee
+     * node and is mandatory for each node.
+     * @param descriptor
+     */
     public void setNodeDescriptor(ZigBeeNodeDescriptor descriptor);
+
+    /*
+     * Gets the {@link ZigBeeNodeDescriptor Node Descriptor}.
+     * <p>
+     * The node descriptor contains information about the capabilities of the ZigBee
+     * node and is mandatory for each node.
+     */
     public ZigBeeNodeDescriptor getNodeDescriptor();
 
+    /**
+     * This sets the {@link ZigBeeNodePowerDescriptor Node Power Descriptor}.
+     * <p>
+     * The node power descriptor gives a dynamic indication of the power status of the
+     * node and is mandatory for each node.
+     * @param descriptor
+     */
     public void setPowerDescriptor(ZigBeeNodePowerDescriptor descriptor);
+
+    /**
+     * This gets the {@link ZigBeeNodePowerDescriptor Node Power Descriptor}.
+     * <p>
+     * The node power descriptor gives a dynamic indication of the power status of the
+     * node and is mandatory for each node.
+     */
     public ZigBeeNodePowerDescriptor getPowerDescriptor();
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeComplexDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeComplexDescriptor.java
@@ -1,0 +1,11 @@
+package org.bubblecloud.zigbee.network;
+
+/*
+ * This implements the Node Complex en join
+ * Descriptor
+ * 
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
+ */
+public class ZigBeeNodeComplexDescriptor {
+
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeDescriptor.java
@@ -5,7 +5,7 @@ import java.util.Map.Entry;
 
 import org.bubblecloud.zigbee.network.packet.zdo.ZDO_NODE_DESC_RSP;
 
-/*
+/**
  * This implements the Node Descriptor.
  * <p>
  * The node descriptor contains information about the capabilities of the ZigBee

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeDescriptor.java
@@ -1,0 +1,134 @@
+package org.bubblecloud.zigbee.network;
+
+import java.util.EnumMap;
+import java.util.Map.Entry;
+
+import org.bubblecloud.zigbee.network.packet.zdo.ZDO_NODE_DESC_RSP;
+
+/*
+ * This implements the Node Descriptor.
+ * <p>
+ * The node descriptor contains information about the capabilities of the ZigBee
+ * node and is mandatory for each node.
+ * <p>
+ * There shall be only one node descriptor in a node.
+ * 
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
+ */
+public class ZigBeeNodeDescriptor {
+	private LOGICAL_TYPE logicalType;
+	private int manufacturerCode;
+	private int maxBufferSize;
+	private int maxTransferSize;
+
+	enum LOGICAL_TYPE {
+		COORDINATOR, ROUTER, END_DEVICE, UNKNOWN
+	}
+
+	private final EnumMap<LOGICAL_TYPE, Integer> typeIndexes = new EnumMap<LOGICAL_TYPE, Integer>(
+			LOGICAL_TYPE.class);
+
+	ZigBeeNodeDescriptor() {
+		typeIndexes.put(LOGICAL_TYPE.COORDINATOR, 0);
+		typeIndexes.put(LOGICAL_TYPE.ROUTER, 1);
+		typeIndexes.put(LOGICAL_TYPE.END_DEVICE, 2);
+		typeIndexes.put(LOGICAL_TYPE.UNKNOWN, -1);
+	}
+
+	public ZigBeeNodeDescriptor(ZDO_NODE_DESC_RSP descriptorResponse) {
+		this();
+
+		logicalType = LOGICAL_TYPE.UNKNOWN;
+		for (Entry<LOGICAL_TYPE, Integer> entry : typeIndexes.entrySet()) {
+			if (entry.getValue() == descriptorResponse.NodeType) {
+				logicalType = entry.getKey();
+			}
+		}
+
+		manufacturerCode = descriptorResponse.ManufacturerCode.get16BitValue();
+		maxBufferSize = descriptorResponse.BufferSize;
+		maxTransferSize = descriptorResponse.TransferSize.get16BitValue();
+	}
+
+	public LOGICAL_TYPE getLogicalType() {
+		return logicalType;
+	}
+
+	/**
+	 * The manufacturer code field of the node descriptor is sixteen bits in
+	 * length and specifies a manufacturer code that is allocated by the ZigBee
+	 * Alliance, relating the manufacturer to the device.
+	 * 
+	 * @return
+	 */
+	public int getManufacturerCode() {
+		return manufacturerCode;
+	}
+
+	/**
+	 * The maximum buffer size field of the node descriptor is eight bits in
+	 * length, with a valid range of 0x00-0x7f. This field specifies the maximum
+	 * size, in octets, of the network sub-layer data unit (NSDU) for this node.
+	 * This is the maximum size of data or commands passed to or from the
+	 * application by the application support sub-layer, before any
+	 * fragmentation or re-assembly.
+	 * 
+	 * This field can be used as a high-level indication for network management.
+	 * 
+	 * @return
+	 */
+	public int getMaximumBufferSize() {
+		return maxBufferSize;
+	}
+
+	/*
+	 * The maximum transfer size field of the node descriptor is sixteen bits in
+	 * length, with a valid range of 0x0000-0x7fff. This field specifies the
+	 * maximum size, in octets, of the application sub-layer data unit (ASDU)
+	 * that can be transferred to this node in one single message transfer. This
+	 * value can exceed the value of the node maximum buffer size field (see
+	 * sub-clause2.3.2.3.8) through the use of fragmentation.
+	 * 
+	 * @return
+	 */
+	public int getMaximumTransferSize() {
+		return maxTransferSize;
+	}
+
+	/*
+	 * The MAC capability flags field is eight bits in length and specifies the
+	 * node capabilities, as required by the IEEE 802.15.4-2003 MAC sub-layer
+	 * [B1]..
+	 * 
+	 * The alternate PAN coordinator sub-field is one bit in length and shall be
+	 * set to 1 if this node is capable of becoming a PAN coordinator.
+	 * Otherwise, the alternative PAN coordinator sub-field shall be set to 0.
+	 * 
+	 * The device type sub-field is one bit in length and shall be set to 1 if
+	 * this node is a full function device (FFD). Otherwise, the device type
+	 * sub-field shall be set to 0, indicating a reduced function device (RFD).
+	 * 
+	 * The power source sub-field is one bit in length and shall be set to 1 if
+	 * the current power source is mains power. Otherwise, the power source
+	 * sub-field shall be set to 0. This information is derived from the node
+	 * current power source field of the node power descriptor.
+	 * 
+	 * The security capability sub-field is one bit in length and shall be set
+	 * to 1 if the device is capable of sending and receiving frames secured
+	 * using the security suite specified in [B1]. Otherwise, the security
+	 * capability sub-field shall be set to 0.
+	 * 
+	 * The receiver on when idle sub-field is one bit in length and shall be set
+	 * to 1 if the device does not disable its receiver to conserve power during
+	 * idle periods. Otherwise, the receiver on when idle sub-field shall be set
+	 * to 0 The allocate address sub-field is one bit in length and shall be set
+	 * to 0 or 1.
+	 */
+
+	/*
+	 * The server mask field of the node descriptor is sixteen bits in length,
+	 * with bit settings signifying the system server capabilities of this node.
+	 * It is used to facilitate discovery of particular system servers by other
+	 * nodes on the system.
+	 */
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeDescriptor.java
@@ -32,7 +32,6 @@ public class ZigBeeNodeDescriptor {
 		typeIndexes.put(LOGICAL_TYPE.COORDINATOR, 0);
 		typeIndexes.put(LOGICAL_TYPE.ROUTER, 1);
 		typeIndexes.put(LOGICAL_TYPE.END_DEVICE, 2);
-		typeIndexes.put(LOGICAL_TYPE.UNKNOWN, -1);
 	}
 
 	public ZigBeeNodeDescriptor(ZDO_NODE_DESC_RSP descriptorResponse) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodePowerDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodePowerDescriptor.java
@@ -1,5 +1,12 @@
 package org.bubblecloud.zigbee.network;
 
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.bubblecloud.zigbee.network.packet.zdo.ZDO_POWER_DESC_RSP;
+
 /*
  * This implements the Node Power Descriptor.
  * <p>
@@ -11,11 +18,85 @@ package org.bubblecloud.zigbee.network;
  * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
  */
 public class ZigBeeNodePowerDescriptor {
+	private POWER_MODE powerMode;
+	private List<POWER_SOURCE> powerSourcesAvailable;
+	private POWER_SOURCE powerSource;
+	private POWER_LEVEL powerLevel;
+
+	enum POWER_MODE {
+		RECEIVER_ON, RECEIVER_PERIODICAL, RECEIVER_USER, UNKNOWN
+	}
+
+	enum POWER_LEVEL {
+		CRITICAL, LOW, GOOD, FULL, UNKNOWN
+	}
+
+	enum POWER_SOURCE {
+		MAINS, BATTERY_RECHARCHABLE, BATTERY_DISPOSABLE, UNKNOWN
+	}
+
+	private final EnumMap<POWER_MODE, Integer> modeIndexes = new EnumMap<POWER_MODE, Integer>(
+			POWER_MODE.class);
+	private final EnumMap<POWER_SOURCE, Integer> sourceIndexes = new EnumMap<POWER_SOURCE, Integer>(
+			POWER_SOURCE.class);
+	private final EnumMap<POWER_LEVEL, Integer> levelIndexes = new EnumMap<POWER_LEVEL, Integer>(
+			POWER_LEVEL.class);
+
+	ZigBeeNodePowerDescriptor() {
+		modeIndexes.put(POWER_MODE.RECEIVER_ON, 0);
+		modeIndexes.put(POWER_MODE.RECEIVER_PERIODICAL, 1);
+		modeIndexes.put(POWER_MODE.RECEIVER_USER, 2);
+
+		sourceIndexes.put(POWER_SOURCE.MAINS, 1);
+		sourceIndexes.put(POWER_SOURCE.BATTERY_RECHARCHABLE, 2);
+		sourceIndexes.put(POWER_SOURCE.BATTERY_DISPOSABLE, 4);
+		sourceIndexes.put(POWER_SOURCE.UNKNOWN, 8);
+
+		levelIndexes.put(POWER_LEVEL.CRITICAL, 0);
+		levelIndexes.put(POWER_LEVEL.LOW, 4);
+		levelIndexes.put(POWER_LEVEL.GOOD, 8);
+		levelIndexes.put(POWER_LEVEL.FULL, 12);
+	}
+
+	public ZigBeeNodePowerDescriptor(ZDO_POWER_DESC_RSP descriptorResponse) {
+		this();
+
+		powerMode = POWER_MODE.UNKNOWN;
+		for (Entry<POWER_MODE, Integer> entry : modeIndexes.entrySet()) {
+			if (entry.getValue() == descriptorResponse.CurrentMode) {
+				powerMode = entry.getKey();
+			}
+		}
+
+		powerSource = POWER_SOURCE.UNKNOWN;
+		for (Entry<POWER_SOURCE, Integer> entry : sourceIndexes.entrySet()) {
+			if (entry.getValue() == descriptorResponse.CurrentSource) {
+				powerSource = entry.getKey();
+			}
+		}
+
+		powerSourcesAvailable = new ArrayList<POWER_SOURCE>();
+		for (Entry<POWER_SOURCE, Integer> entry : sourceIndexes.entrySet()) {
+			if ((entry.getValue() & descriptorResponse.AvailableSources) == 1) {
+				powerSourcesAvailable.add(entry.getKey());
+			}
+		}
+
+		powerLevel = POWER_LEVEL.UNKNOWN;
+		for (Entry<POWER_LEVEL, Integer> entry : levelIndexes.entrySet()) {
+			if (entry.getValue() == descriptorResponse.CurrentLevel) {
+				powerLevel = entry.getKey();
+			}
+		}
+	}
 
 	/*
 	 * The current power mode field of the node power descriptor is four bits in
 	 * length and specifies the current sleep/power-saving mode of the node.
 	 */
+	public POWER_MODE getPowerMode() {
+		return powerMode;
+	}
 
 	/*
 	 * The available power sources field of the node power descriptor is four
@@ -24,6 +105,9 @@ public class ZigBeeNodePowerDescriptor {
 	 * the available power sources field, shall be set to 1. All other bits
 	 * shall be set to 0.
 	 */
+	public List<POWER_SOURCE> getPowerSourcesAvailable() {
+		return powerSourcesAvailable;
+	}
 
 	/*
 	 * The current power source field of the node power descriptor is four bits
@@ -32,6 +116,9 @@ public class ZigBeeNodePowerDescriptor {
 	 * current power source field, shall be set to 1. All other bits shall be
 	 * set to 0.
 	 */
+	public POWER_SOURCE getPowerSource() {
+		return powerSource;
+	}
 
 	/*
 	 * The current power source level field of the node power descriptor is four
@@ -39,4 +126,7 @@ public class ZigBeeNodePowerDescriptor {
 	 * current power source level field shall be set to one of the non-reserved
 	 * values.
 	 */
+	public POWER_LEVEL getPowerLevel() {
+		return powerLevel;
+	}
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodePowerDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodePowerDescriptor.java
@@ -7,7 +7,7 @@ import java.util.Map.Entry;
 
 import org.bubblecloud.zigbee.network.packet.zdo.ZDO_POWER_DESC_RSP;
 
-/*
+/**
  * This implements the Node Power Descriptor.
  * <p>
  * The node power descriptor gives a dynamic indication of the power status of the

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodePowerDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodePowerDescriptor.java
@@ -1,0 +1,42 @@
+package org.bubblecloud.zigbee.network;
+
+/*
+ * This implements the Node Power Descriptor.
+ * <p>
+ * The node power descriptor gives a dynamic indication of the power status of the
+ * node and is mandatory for each node.
+ * <p>
+ * There shall be only one node power descriptor in a node.
+ * 
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
+ */
+public class ZigBeeNodePowerDescriptor {
+
+	/*
+	 * The current power mode field of the node power descriptor is four bits in
+	 * length and specifies the current sleep/power-saving mode of the node.
+	 */
+
+	/*
+	 * The available power sources field of the node power descriptor is four
+	 * bits in length and specifies the power sources available on this node.
+	 * For each power source supported on this node, the corresponding bit of
+	 * the available power sources field, shall be set to 1. All other bits
+	 * shall be set to 0.
+	 */
+
+	/*
+	 * The current power source field of the node power descriptor is four bits
+	 * in length and specifies the current power source being utilized by the
+	 * node. For the current power source selected, the corresponding bit of the
+	 * current power source field, shall be set to 1. All other bits shall be
+	 * set to 0.
+	 */
+
+	/*
+	 * The current power source level field of the node power descriptor is four
+	 * bits in length and specifies the level of charge of the power source. The
+	 * current power source level field shall be set to one of the non-reserved
+	 * values.
+	 */
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeUserDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeUserDescriptor.java
@@ -1,0 +1,10 @@
+package org.bubblecloud.zigbee.network;
+
+/*
+ * This implements the Node User Descriptor
+ * 
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
+ */
+public class ZigBeeNodeUserDescriptor {
+
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
@@ -26,6 +26,7 @@ import org.bubblecloud.zigbee.network.ZigBeeEndpoint;
 import org.bubblecloud.zigbee.network.ZigBeeNode;
 import org.bubblecloud.zigbee.network.ZigBeeNetworkManager;
 import org.bubblecloud.zigbee.network.ZigBeeNodeDescriptor;
+import org.bubblecloud.zigbee.network.ZigBeeNodePowerDescriptor;
 import org.bubblecloud.zigbee.network.impl.*;
 import org.bubblecloud.zigbee.network.packet.ZToolAddress16;
 import org.bubblecloud.zigbee.network.packet.ZToolAddress64;
@@ -212,12 +213,13 @@ public class EndpointBuilder implements Stoppable {
 
             // Get the power descriptor
             ZDO_POWER_DESC_REQ powerDescriptorReq = new ZDO_POWER_DESC_REQ(nwkAddress.get16BitValue());
-            final ZDO_POWER_DESC_RSP result = driver.sendZDOPowerDescriptionRequest(powerDescriptorReq);
-            if (result == null) {
+            final ZDO_POWER_DESC_RSP powerResult = driver.sendZDOPowerDescriptionRequest(powerDescriptorReq);
+            if (powerResult == null) {
                 logger.warn("ZDO_POWER_DESC_REQ FAILED on {}", node);
             }
             else {
-            	// TODO: Save the power descriptor
+            	// Save the power descriptor
+            	node.setPowerDescriptor(new ZigBeeNodePowerDescriptor(powerResult));
             }
 
             // Get a list of supported endpoints

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
@@ -30,11 +30,16 @@ import org.bubblecloud.zigbee.network.packet.ZToolAddress16;
 import org.bubblecloud.zigbee.network.packet.ZToolAddress64;
 import org.bubblecloud.zigbee.network.packet.zdo.ZDO_ACTIVE_EP_REQ;
 import org.bubblecloud.zigbee.network.packet.zdo.ZDO_ACTIVE_EP_RSP;
+import org.bubblecloud.zigbee.network.packet.zdo.ZDO_NODE_DESC_REQ;
+import org.bubblecloud.zigbee.network.packet.zdo.ZDO_NODE_DESC_RSP;
+import org.bubblecloud.zigbee.network.packet.zdo.ZDO_POWER_DESC_REQ;
+import org.bubblecloud.zigbee.network.packet.zdo.ZDO_POWER_DESC_RSP;
 import org.bubblecloud.zigbee.util.Stoppable;
 import org.bubblecloud.zigbee.util.ThreadUtils;
 import org.bubblecloud.zigbee.network.model.IEEEAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.*;
@@ -49,7 +54,7 @@ import java.util.Map.Entry;
  * @author <a href="mailto:stefano.lenzi@isti.cnr.it">Stefano "Kismet" Lenzi</a>
  * @author <a href="mailto:francesco.furfari@isti.cnr.it">Francesco Furfari</a>
  * @author <a href="mailto:manlio.bacco@isti.cnr.it">Manlio Bacco</a>
- * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
  * @since 0.1.0
  */
 public class EndpointBuilder implements Stoppable {
@@ -87,20 +92,17 @@ public class EndpointBuilder implements Stoppable {
         this.driver = driver;
     }
 
-
-    private ZDO_ACTIVE_EP_RSP doInspectEndpointOfNode(final int nwkAddress, final ZigBeeNode node) {
-        logger.trace("Listing end points on node #{} to find devices.", nwkAddress);
-
+    private boolean inspectEndpointOfNode(final int nwkAddress, final ZigBeeNode node) {
         int i = 0;
         ZDO_ACTIVE_EP_RSP result = null;
 
-        while (i < 1) {
+        while (i <= 1) {
             result = driver.sendZDOActiveEndPointRequest(new ZDO_ACTIVE_EP_REQ(nwkAddress));
 
             if (result == null) {
                 final long waiting = 1000;
                 logger.trace(
-                        "Inspecting device on node {} failed during it {}-nth attempt. " +
+                        "Inspecting device on node {} failed during the {}-nth attempt. " +
                                 "Waiting for {}ms before retrying",
                         new Object[]{node, i, waiting}
                 );
@@ -111,12 +113,6 @@ public class EndpointBuilder implements Stoppable {
             }
         }
 
-        return result;
-    }
-
-    private boolean inspectEndpointOfNode(final int nwkAddress, final ZigBeeNode node) {
-
-        final ZDO_ACTIVE_EP_RSP result = doInspectEndpointOfNode(nwkAddress, node);
         if (result == null) {
             logger.warn("ZDO_ACTIVE_EP_REQ FAILED on {}", node);
             return false;
@@ -124,7 +120,7 @@ public class EndpointBuilder implements Stoppable {
 
         short[] endPoints = result.getActiveEndPointList();
         logger.trace("Found {} end points on #{}.", endPoints.length, nwkAddress);
-        for (int i = 0; i < endPoints.length; i++) {
+        for (i = 0; i < endPoints.length; i++) {
             doCreateZigBeeEndpoint(node, endPoints[i]);
         }
 
@@ -190,7 +186,39 @@ public class EndpointBuilder implements Stoppable {
             }
         }
         if (isNew) {
-            //logger.info("Inspecting node #{} devices.", nwk);
+        	// This is a new node
+
+        	// Get the device descriptor
+            ZDO_NODE_DESC_REQ nodeDescriptorReq = new ZDO_NODE_DESC_REQ(nwkAddress.get16BitValue());
+            final ZDO_NODE_DESC_RSP nodeResult = driver.sendZDONodeDescriptionRequest(nodeDescriptorReq);
+            if (nodeResult == null) {
+                logger.warn("ZDO_NODE_DESC_REQ FAILED on {}", node);
+            }
+            else {
+            	// TODO: Save the relevant parts of the descriptor in the node
+
+                // If there's an advanced descriptor, get it
+                if(nodeResult.ComplexDescriptorAvailable == 1) {
+                	// TODO: Save node complex descriptor
+                }
+
+                // If there's a user defined descriptor, get it
+                if(nodeResult.UserDescriptorAvailable == 1) {
+                	// TODO: Save node user descriptor
+                }
+            }
+
+            // Get the power descriptor
+            ZDO_POWER_DESC_REQ powerDescriptorReq = new ZDO_POWER_DESC_REQ(nwkAddress.get16BitValue());
+            final ZDO_POWER_DESC_RSP result = driver.sendZDOPowerDescriptionRequest(powerDescriptorReq);
+            if (result == null) {
+                logger.warn("ZDO_POWER_DESC_REQ FAILED on {}", node);
+            }
+            else {
+            	// TODO: Save the power descriptor
+            }
+
+            // Get a list of supported endpoints
             correctlyInspected = inspectEndpointOfNode(nwk, node);
             if (correctlyInspected) {
                 return;

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
@@ -25,6 +25,7 @@ package org.bubblecloud.zigbee.network.discovery;
 import org.bubblecloud.zigbee.network.ZigBeeEndpoint;
 import org.bubblecloud.zigbee.network.ZigBeeNode;
 import org.bubblecloud.zigbee.network.ZigBeeNetworkManager;
+import org.bubblecloud.zigbee.network.ZigBeeNodeDescriptor;
 import org.bubblecloud.zigbee.network.impl.*;
 import org.bubblecloud.zigbee.network.packet.ZToolAddress16;
 import org.bubblecloud.zigbee.network.packet.ZToolAddress64;
@@ -188,14 +189,15 @@ public class EndpointBuilder implements Stoppable {
         if (isNew) {
         	// This is a new node
 
-        	// Get the device descriptor
+        	// Get the node descriptor
             ZDO_NODE_DESC_REQ nodeDescriptorReq = new ZDO_NODE_DESC_REQ(nwkAddress.get16BitValue());
             final ZDO_NODE_DESC_RSP nodeResult = driver.sendZDONodeDescriptionRequest(nodeDescriptorReq);
             if (nodeResult == null) {
                 logger.warn("ZDO_NODE_DESC_REQ FAILED on {}", node);
             }
             else {
-            	// TODO: Save the relevant parts of the descriptor in the node
+            	// Save the descriptor in the node
+            	node.setNodeDescriptor(new ZigBeeNodeDescriptor(nodeResult));
 
                 // If there's an advanced descriptor, get it
                 if(nodeResult.ComplexDescriptorAvailable == 1) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNetwork.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNetwork.java
@@ -34,7 +34,7 @@ import java.util.*;
 /**
  * @author <a href="mailto:stefano.lenzi@isti.cnr.it">Stefano "Kismet" Lenzi</a>
  * @author <a href="mailto:francesco.furfari@isti.cnr.it">Francesco Furfari</a>
- * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
  */
 public class ZigBeeNetwork {
 
@@ -57,6 +57,14 @@ public class ZigBeeNetwork {
      */
     public Hashtable<ZigBeeNode, HashMap<Integer, ZigBeeEndpoint>> getDevices() {
         return devices;
+    }
+    
+    /**
+     * Gets the list of devices
+     * @return
+     */
+    public Hashtable<String, ZigBeeNodeImpl> getNodes() {
+    	return nodes;
     }
 
     /**

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNodeImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNodeImpl.java
@@ -47,8 +47,9 @@ public class ZigBeeNodeImpl implements ZigBeeNode {
      * The pan.
      */
     private short pan;
-    
+
     private ZigBeeNodeDescriptor nodeDescriptor;
+    private ZigBeeNodePowerDescriptor powerDescriptor;
 
     /**
      * Default constructor.
@@ -135,14 +136,12 @@ public class ZigBeeNodeImpl implements ZigBeeNode {
 
 	@Override
 	public void setPowerDescriptor(ZigBeeNodePowerDescriptor descriptor) {
-		// TODO Auto-generated method stub
-		
+		powerDescriptor = descriptor;
 	}
 
 	@Override
 	public ZigBeeNodePowerDescriptor getPowerDescriptor() {
-		// TODO Auto-generated method stub
-		return null;
+		return powerDescriptor;
 	}
 
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNodeImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNodeImpl.java
@@ -48,7 +48,14 @@ public class ZigBeeNodeImpl implements ZigBeeNode {
      */
     private short pan;
 
+    /*
+     * The basic node descriptor
+     */
     private ZigBeeNodeDescriptor nodeDescriptor;
+    
+    /*
+     * The node power descriptor
+     */
     private ZigBeeNodePowerDescriptor powerDescriptor;
 
     /**

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNodeImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNodeImpl.java
@@ -23,6 +23,8 @@
 package org.bubblecloud.zigbee.network.impl;
 
 import org.bubblecloud.zigbee.network.ZigBeeNode;
+import org.bubblecloud.zigbee.network.ZigBeeNodeDescriptor;
+import org.bubblecloud.zigbee.network.ZigBeeNodePowerDescriptor;
 import org.bubblecloud.zigbee.network.packet.ZToolAddress64;
 import org.bubblecloud.zigbee.network.model.IEEEAddress;
 
@@ -45,6 +47,8 @@ public class ZigBeeNodeImpl implements ZigBeeNode {
      * The pan.
      */
     private short pan;
+    
+    private ZigBeeNodeDescriptor nodeDescriptor;
 
     /**
      * Default constructor.
@@ -118,5 +122,27 @@ public class ZigBeeNodeImpl implements ZigBeeNode {
     public int hashCode() {
         return ieeeAddress.hashCode();
     }
+
+	@Override
+	public void setNodeDescriptor(ZigBeeNodeDescriptor descriptor) {
+		nodeDescriptor = descriptor;
+	}
+
+	@Override
+	public ZigBeeNodeDescriptor getNodeDescriptor() {
+		return nodeDescriptor;
+	}
+
+	@Override
+	public void setPowerDescriptor(ZigBeeNodePowerDescriptor descriptor) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public ZigBeeNodePowerDescriptor getPowerDescriptor() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolCMD.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolCMD.java
@@ -690,7 +690,7 @@ public class ZToolCMD {
     /// <summary>Response for ZDO_USER_DESC_SET</summary>
     public static final int ZDO_USER_DESC_SET_SRSP = 0x650b;
     /// <name>TI.ZPI2.MESSAGE_ID.ZMAC_ASSOCIATE_CNF</name>
-    /// <summary>This sends a associat confirm command</summary>
+    /// <summary>This sends an associate confirm command</summary>
     public static final int ZMAC_ASSOCIATE_CNF = 0x4282;
     /// <name>TI.ZPI2.MESSAGE_ID.ZMAC_ASSOCIATE_IND</name>
     /// <summary>This command is used to send (on behalf of the next higher layer) an association indication message</summary>
@@ -705,7 +705,7 @@ public class ZToolCMD {
     /// <summary>Beacon Notify Indication</summary>
     public static final int ZMAC_BEACON_NOTIFY_IND = 0x4283;
     /// <name>TI.ZPI2.MESSAGE_ID.ZMAC_COMM_STATUS_IND</name>
-    /// <summary>Communcation status indication</summary>
+    /// <summary>Communication status indication</summary>
     public static final int ZMAC_COMM_STATUS_IND = 0x428d;
     /// <name>TI.ZPI2.MESSAGE_ID.ZMAC_DATA_CNF</name>
     /// <summary>Data Request Confirmation</summary>

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketStream.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolPacketStream.java
@@ -311,6 +311,10 @@ public class ZToolPacketStream
                 return new ZDO_NODE_DESC_REQ_SRSP(payload);
             case ZToolCMD.ZDO_NODE_DESC_RSP:
                 return new ZDO_NODE_DESC_RSP(payload);
+            case ZToolCMD.ZDO_POWER_DESC_REQ_SRSP:
+                return new ZDO_POWER_DESC_REQ_SRSP(payload);
+            case ZToolCMD.ZDO_POWER_DESC_RSP:
+                return new ZDO_POWER_DESC_RSP(payload);
             case ZToolCMD.ZDO_NWK_ADDR_REQ_SRSP:
                 return new ZDO_NWK_ADDR_REQ_SRSP(payload);
             case ZToolCMD.ZDO_NWK_ADDR_RSP:

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MGMT_PERMIT_JOIN_REQ.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MGMT_PERMIT_JOIN_REQ.java
@@ -23,7 +23,6 @@
 
 package org.bubblecloud.zigbee.network.packet.zdo;
 
-import org.bubblecloud.zigbee.network.packet.ZToolAddress;
 import org.bubblecloud.zigbee.network.packet.ZToolAddress16;
 import org.bubblecloud.zigbee.network.packet.ZToolCMD;
 import org.bubblecloud.zigbee.network.packet.ZToolPacket;

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_INCOMING.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_MSG_CB_INCOMING.java
@@ -49,6 +49,7 @@ public class ZDO_MSG_CB_INCOMING extends ZToolPacket /*implements IRESPONSE_CALL
         build.put(0x8000, ZDO_NWK_ADDR_RSP.class);
         build.put(0x8001, ZDO_IEEE_ADDR_RSP.class);
         build.put(0x8002, ZDO_NODE_DESC_RSP.class);
+        build.put(0x8003, ZDO_POWER_DESC_RSP.class);
         build.put(0x8004, ZDO_SIMPLE_DESC_RSP.class);
         build.put(0x8005, ZDO_ACTIVE_EP_RSP.class);
         build.put(0x8006, ZDO_MATCH_DESC_RSP.class);

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_NODE_DESC_RSP.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_NODE_DESC_RSP.java
@@ -31,7 +31,7 @@ import org.bubblecloud.zigbee.util.DoubleByte;
 
 /**
  * @author <a href="mailto:alfiva@aaa.upv.es">Alvaro Fides Valero</a>
- * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
  */
 public class ZDO_NODE_DESC_RSP extends ZToolPacket /*implements IRESPONSE_CALLBACK,IZDO*/ {
     /// <name>TI.ZPI1.ZDO_NODE_DESC_RSP.APSFlags</name>

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_POWER_DESC_REQ.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_POWER_DESC_REQ.java
@@ -34,35 +34,32 @@ import org.bubblecloud.zigbee.util.DoubleByte;
 import org.bubblecloud.zigbee.util.Integers;
 
 /**
- * @author <a href="mailto:stefano.lenzi@isti.cnr.it">Stefano "Kismet" Lenzi</a>
- * @author <a href="mailto:alfiva@aaa.upv.es">Alvaro Fides Valero</a>
- * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)
- * @since 0.1.0
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
  */
-public class ZDO_NODE_DESC_REQ extends ZToolPacket /*implements IREQUEST,IZDO*/ {
-    /// <name>TI.ZPI1.ZDO_NODE_DESC_REQ.DstAddr</name>
+public class ZDO_POWER_DESC_REQ extends ZToolPacket /*implements IREQUEST,IZDO*/ {
+    /// <name>TI.ZPI1.ZDO_POWER_DESC_REQ.DstAddr</name>
     /// <summary>destination address</summary>
     public ZToolAddress16 DstAddr;
-    /// <name>TI.ZPI1.ZDO_NODE_DESC_REQ.NWKAddrOfInterest</name>
+    /// <name>TI.ZPI1.ZDO_POWER_DESC_REQ.NWKAddrOfInterest</name>
     /// <summary>NWK address for the request</summary>
     public ZToolAddress16 NWKAddrOfInterest;
 
-    /// <name>TI.ZPI1.ZDO_NODE_DESC_REQ</name>
+    /// <name>TI.ZPI1.ZDO_POWER_DESC_REQ</name>
     /// <summary>Constructor</summary>
-    public ZDO_NODE_DESC_REQ() {
+    public ZDO_POWER_DESC_REQ() {
     }
 
-    public ZDO_NODE_DESC_REQ(int destination) {
+    public ZDO_POWER_DESC_REQ(int destination) {
         //TODO Check compatibility with other Constructor
         int[] framedata = new int[4];
         framedata[0] = Integers.getByteAsInteger(destination, 0);
         framedata[1] = Integers.getByteAsInteger(destination, 1);
         framedata[2] = framedata[0];
         framedata[3] = framedata[1];
-        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_NODE_DESC_REQ), framedata);
+        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_POWER_DESC_REQ), framedata);
     }
 
-    public ZDO_NODE_DESC_REQ(ZToolAddress16 num1, ZToolAddress16 num2) {
+    public ZDO_POWER_DESC_REQ(ZToolAddress16 num1, ZToolAddress16 num2) {
         this.DstAddr = num1;
         this.NWKAddrOfInterest = num2;
 
@@ -71,7 +68,7 @@ public class ZDO_NODE_DESC_REQ extends ZToolPacket /*implements IREQUEST,IZDO*/ 
         framedata[1] = this.DstAddr.getMsb();
         framedata[2] = this.NWKAddrOfInterest.getLsb();
         framedata[3] = this.NWKAddrOfInterest.getMsb();
-        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_NODE_DESC_REQ), framedata);
+        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_POWER_DESC_REQ), framedata);
     }
 
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_POWER_DESC_REQ_SRSP.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_POWER_DESC_REQ_SRSP.java
@@ -28,25 +28,28 @@ import org.bubblecloud.zigbee.network.packet.ZToolCMD;
 import org.bubblecloud.zigbee.network.packet.ZToolPacket;
 import org.bubblecloud.zigbee.util.DoubleByte;
 
-
 /**
- * Response for requesting the network to switch channel or change PAN PROFILE_ID_HOME_AUTOMATION.
- *
- * @author <a href="mailto:tommmi.s.e.laukkanen@gmail.com">Tommi S.E. Laukkanen</a>
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
  */
-public class ZDO_MGMT_NWK_UPDATE_REQ_SRSP extends ZToolPacket {
+public class ZDO_POWER_DESC_REQ_SRSP extends ZToolPacket/* implements IRESPONSE,IZDo*/ {
+    /// <name>TI.ZPI1.ZDO_POWER_DESC_REQ_SRSP.Status</name>
+    /// <summary>Status</summary>
     public int Status;
 
-    public ZDO_MGMT_NWK_UPDATE_REQ_SRSP(int[] framedata) {
+    /// <name>TI.ZPI1.ZDO_POWER_DESC_REQ_SRSP</name>
+    /// <summary>Constructor</summary>
+    public ZDO_POWER_DESC_REQ_SRSP() {
+    }
+
+    public ZDO_POWER_DESC_REQ_SRSP(int[] framedata) {
         this.Status = framedata[0];
-        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_MGMT_NWK_UPDATE_REQ_SRSP), framedata);
+        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_POWER_DESC_REQ_SRSP), framedata);
     }
 
     @Override
     public String toString() {
-        return "ZDO_MGMT_NWK_UPDATE_REQ_SRSP{" +
+        return "ZDO_POWER_DESC_REQ_SRSP{" +
                 "Status=" + ResponseStatus.getStatus(Status) +
                 '}';
     }
-
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_POWER_DESC_RSP.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_POWER_DESC_RSP.java
@@ -1,0 +1,81 @@
+/*
+   Copyright 2008-2013 ITACA-TSB, http://www.tsb.upv.es/
+   Instituto Tecnologico de Aplicaciones de Comunicacion 
+   Avanzadas - Grupo Tecnologias para la Salud y el 
+   Bienestar (TSB)
+
+
+   See the NOTICE file distributed with this work for additional 
+   information regarding copyright ownership
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package org.bubblecloud.zigbee.network.packet.zdo;
+
+import org.bubblecloud.zigbee.network.packet.ResponseStatus;
+import org.bubblecloud.zigbee.network.packet.ZToolAddress16;
+import org.bubblecloud.zigbee.network.packet.ZToolCMD;
+import org.bubblecloud.zigbee.network.packet.ZToolPacket;
+import org.bubblecloud.zigbee.util.DoubleByte;
+
+/**
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
+ */
+public class ZDO_POWER_DESC_RSP extends ZToolPacket /*implements IRESPONSE_CALLBACK,IZDO*/ {
+    /// <name>TI.ZPI1.ZDO_NODE_DESC_RSP.NWKAddrOfInterest</name>
+    /// <summary>Device's short address of this Node descriptor</summary>
+    public ZToolAddress16 nwkAddr;
+    /// <name>TI.ZPI1.ZDO_NODE_DESC_RSP.SrcAddress</name>
+    /// <summary>the message's source network address.</summary>
+    public ZToolAddress16 SrcAddress;
+    /// <name>TI.ZPI1.ZDO_NODE_DESC_RSP.Status</name>
+    /// <summary>this field indicates either SUCCESS or FAILURE.</summary>
+    public int Status;
+
+    // TODO: Add doc!
+    public int CurrentMode;
+    public int AvailableSources;
+    public int CurrentSource;
+    public int CurrentLevel;
+    
+    /// <name>TI.ZPI1.ZDO_NODE_DESC_RSP</name>
+    /// <summary>Constructor</summary>
+    public ZDO_POWER_DESC_RSP() {
+    }
+
+    public ZDO_POWER_DESC_RSP(int[] framedata) {
+        this.SrcAddress = new ZToolAddress16(framedata[1], framedata[0]);
+        this.Status = framedata[2];
+        this.nwkAddr = new ZToolAddress16(framedata[4], framedata[3]);
+        this.CurrentMode = (framedata[5] & (0x0F));
+        this.AvailableSources = (framedata[5] & (0xF0)) >> 4;
+        this.CurrentSource = (framedata[6] & (0x0F));
+        this.CurrentLevel = (framedata[6] & (0xF0)) >> 4;
+
+        super.buildPacket(new DoubleByte(ZToolCMD.ZDO_POWER_DESC_RSP), framedata);
+    }
+
+    @Override
+    public String toString() {
+        return "ZDO_NODE_DESC_RSP{" +
+                "nwkAddr=" + nwkAddr +
+                ", SrcAddress=" + SrcAddress +
+                ", Status=" + ResponseStatus.getStatus(Status) +
+                ", CurrentMode=" + CurrentMode +
+                ", AvailableSources=" + AvailableSources +
+                ", CurrentSource=" + CurrentSource +
+                ", CurrentLevel=" + CurrentLevel +
+                "}";
+    }
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeInterface.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeInterface.java
@@ -55,8 +55,8 @@ public class ZigBeeInterface implements ZToolPacketHandler {
      */
     private ZToolPacketParser parser;
     /**
-     * Support paraller processing of different command types. Only one command per command ID can be in process
-     * at a time.
+     * Support parallel processing of different command types.
+     * Only one command per command ID can be in process at a time.
      */
     private final boolean supportMultipleSynchrounsCommand = false;
     /**
@@ -96,7 +96,7 @@ public class ZigBeeInterface implements ZToolPacketHandler {
     }
 
     /**
-     * Closes connection ot ZigBee Network.
+     * Closes connection to ZigBee Network.
      */
     public void close() {
         synchronized (port) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -654,6 +654,26 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
         return result;
     }
 
+    public ZDO_POWER_DESC_RSP sendZDOPowerDescriptionRequest(ZDO_POWER_DESC_REQ request) {
+        if (waitForNetwork() == false) {
+        	return null;
+        }
+        ZDO_POWER_DESC_RSP result = null;
+
+        waitAndLock3WayConversation(request);
+        final WaitForCommand waiter = new WaitForCommand(ZToolCMD.ZDO_POWER_DESC_RSP, zigbeeInterface);
+
+        ZDO_POWER_DESC_REQ_SRSP response = (ZDO_POWER_DESC_REQ_SRSP) sendSynchrouns(zigbeeInterface, request);
+        if (response == null || response.Status != 0) {
+            waiter.cleanup();
+        } else {
+            result = (ZDO_POWER_DESC_RSP) waiter.getCommand(TIMEOUT);
+        }
+
+        unLock3WayConversation(request);
+        return result;
+    }
+
     public ZDO_ACTIVE_EP_RSP sendZDOActiveEndPointRequest(ZDO_ACTIVE_EP_REQ request) {
         if (waitForNetwork() == false) {
         	return null;

--- a/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -13,6 +13,8 @@ import org.bubblecloud.zigbee.api.cluster.impl.api.core.ReportListener;
 import org.bubblecloud.zigbee.api.cluster.impl.api.core.Reporter;
 import org.bubblecloud.zigbee.api.cluster.impl.api.core.ZigBeeClusterException;
 import org.bubblecloud.zigbee.api.cluster.general.ColorControl;
+import org.bubblecloud.zigbee.network.ZigBeeNode;
+import org.bubblecloud.zigbee.network.ZigBeeNodeDescriptor;
 import org.bubblecloud.zigbee.network.impl.ZigBeeNetworkManagerException;
 import org.bubblecloud.zigbee.network.port.ZigBeePort;
 import org.bubblecloud.zigbee.network.model.DiscoveryMode;
@@ -62,6 +64,7 @@ public final class ZigBeeConsole {
 		commands.put("quit", 		new QuitCommand());
 		commands.put("help", 		new HelpCommand());
 		commands.put("list", 		new ListCommand());
+		commands.put("nodes", 		new NodesCommand());
 		commands.put("desc", 		new DescribeCommand());
 		commands.put("bind", 		new BindCommand());
 		commands.put("unbind", 		new UnbindCommand());
@@ -382,6 +385,47 @@ public final class ZigBeeConsole {
                 		" [" + device.getNetworkAddress() + "]" +
                 		" : " + device.getDeviceType());
             }
+            return true;
+        }
+    }
+
+    /**
+     * Prints list of devices to console.
+     */
+    private class NodesCommand implements ConsoleCommand {
+        /**
+         * {@inheritDoc}
+         */
+        public String getDescription() {
+            return "Lists node information.";
+        }
+        /**
+         * {@inheritDoc}
+         */
+        public String getSyntax() {
+            return "nodes";
+        }
+        /**
+         * {@inheritDoc}
+         */
+        public boolean process(final ZigBeeApi zigbeeApi, final String[] args) {
+            final List<ZigBeeNode> nodes = zigbeeApi.getNodes();
+            for (int i = 0; i < nodes.size(); i++) {
+                final ZigBeeNode node = nodes.get(i);
+                print("IEEE Address     : " + node.getIeeeAddress());
+                print("Network Address  : " + String.format("%04X", node.getNetworkAddress()));
+
+	        	ZigBeeNodeDescriptor nodeDescriptor = node.getNodeDescriptor();
+	        	if(nodeDescriptor != null) {
+		            print("Node Descriptor  : Logical Type       " + nodeDescriptor.getLogicalType());
+	        		print("                 : Manufacturer Code  " + String.format("%04X", nodeDescriptor.getManufacturerCode()));
+	        		print("                 : Max Buffer Size    " + nodeDescriptor.getMaximumBufferSize());
+	        		print("                 : Max Transfer Size  " + nodeDescriptor.getMaximumTransferSize());
+	        	}
+	            print("-");
+            }
+            
+
             return true;
         }
     }

--- a/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -15,6 +15,7 @@ import org.bubblecloud.zigbee.api.cluster.impl.api.core.ZigBeeClusterException;
 import org.bubblecloud.zigbee.api.cluster.general.ColorControl;
 import org.bubblecloud.zigbee.network.ZigBeeNode;
 import org.bubblecloud.zigbee.network.ZigBeeNodeDescriptor;
+import org.bubblecloud.zigbee.network.ZigBeeNodePowerDescriptor;
 import org.bubblecloud.zigbee.network.impl.ZigBeeNetworkManagerException;
 import org.bubblecloud.zigbee.network.port.ZigBeePort;
 import org.bubblecloud.zigbee.network.model.DiscoveryMode;
@@ -33,6 +34,7 @@ import java.util.*;
  *
  * @author <a href="mailto:tommi.s.e.laukkanen@gmail.com">Tommi S.E. Laukkanen</a>
  * @author <a href="mailto:christopherhattonuk@gmail.com">Chris Hatton</a>
+ * @author <a href="mailto:chris@cd-jackson.com">Chris Jackson</a>
  */
 public final class ZigBeeConsole {
     /**
@@ -422,9 +424,16 @@ public final class ZigBeeConsole {
 	        		print("                 : Max Buffer Size    " + nodeDescriptor.getMaximumBufferSize());
 	        		print("                 : Max Transfer Size  " + nodeDescriptor.getMaximumTransferSize());
 	        	}
+	        	
+	        	ZigBeeNodePowerDescriptor powerDescriptor = node.getPowerDescriptor();
+	        	if(powerDescriptor != null) {
+		            print("Power Descriptor : Power Mode         " + powerDescriptor.getPowerMode());
+		            print("                 : Power Source       " + powerDescriptor.getPowerSource());
+		            print("                 : Power Level        " + powerDescriptor.getPowerLevel());
+		            print("                 : Power Available    " + powerDescriptor.getPowerSourcesAvailable());
+	        	}
 	            print("-");
             }
-            
 
             return true;
         }


### PR DESCRIPTION
This adds code to get the node descriptors during the node discovery phase. It currently gets the node descriptor and power descriptor, although only the node descriptor is (reasonably) properly implemented.

This is work in progress, but I thought I'd give visibility especially as @presslab-us is also working in this area...