### PR TITLE
Add node listener to get notifications about when a node is added, discovered and removed

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeApi.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeApi.java
@@ -16,6 +16,7 @@
 package org.bubblecloud.zigbee;
 
 import org.bubblecloud.zigbee.network.EndpointListener;
+import org.bubblecloud.zigbee.network.NodeListener;
 import org.bubblecloud.zigbee.network.ZigBeeEndpoint;
 import org.bubblecloud.zigbee.network.ZigBeeNode;
 import org.bubblecloud.zigbee.network.discovery.ZigBeeDiscoveryManager;
@@ -470,4 +471,22 @@ public class ZigBeeApi implements EndpointListener {
             context.removeDevice(device);
         }
     }
+    
+    /**
+     * Adds a {@link NodeListener node listener}. The listener will be notified for each new {@link ZigBeeNode}
+     * that is found.
+     * @param deviceListener {@link NodeListener}
+     */
+    public void addNodeListener(NodeListener nodeListener) {
+        network.addNodeListener(nodeListener);
+    }
+
+    /**
+     * Removes a previously registered node listener
+     * @param nodeListener {@link NodeListener}
+     */
+    public void removeNodeListener(NodeListener nodeListener) {
+        network.removeNodeListener(nodeListener);
+    }
+
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeApi.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/ZigBeeApi.java
@@ -410,9 +410,9 @@ public class ZigBeeApi implements EndpointListener {
     }
 
     /**
-     * Gets the list of current {@link ZigBeeNode ZigBee nodes}
+     * Gets the list of current {@link ZigBeeNode}s
      * 
-     * @return the list of current ZigBee nodes
+     * @return the list of current {@link ZigBeeNode}s
      */
     public List<ZigBeeNode> getNodes() {
     	ArrayList<ZigBeeNode> nodes = new ArrayList<ZigBeeNode>();
@@ -421,6 +421,15 @@ public class ZigBeeApi implements EndpointListener {
         }
 
         return nodes;
+    }
+
+    /**
+     * Gets the list of current {@link ZigBeeEndpoint}s within the specified {@link ZigBeeNode}
+     * 
+     * @return the list of {@link ZigBeeEndpoint}s
+     */
+    public List<ZigBeeEndpoint> getNodeEndpoints(ZigBeeNode node) {
+    	return network.getEndpoints(node);
     }
 
     /**

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/ClusterFactoryBase.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/ClusterFactoryBase.java
@@ -32,6 +32,11 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 
 /**
+ * Implements the base cluster factory.
+ * <p>
+ * This provides the base functionality of the cluster factory - specific implementations, for different
+ * ZigBee profiles need only to extend this base factor to add the clusters they implement.
+ * 
  * @author <a href="mailto:stefano.lenzi@isti.cnr.it">Stefano "Kismet" Lenzi</a>
  * @author <a href="mailto:francesco.furfari@isti.cnr.it">Francesco Furfari</a>
  * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/ClusterFactoryImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/ClusterFactoryImpl.java
@@ -129,12 +129,8 @@ public class ClusterFactoryImpl extends ClusterFactoryBase {
         addCluster(DOOR_LOCK_KEY, DoorLockImpl.class);
         addCluster(WINDOW_COVERING_KEY, WindowCoveringImpl.class);
 
-
         //Lighting
         addCluster(COLOR_CONTROL_KEY, ColorControlImpl.class);
-
-
     }
-
 
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/DeviceBase.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/DeviceBase.java
@@ -161,7 +161,7 @@ public abstract class DeviceBase implements Device {
         if (!endpoint.providesInputCluster(clusterId) && getDescription().isOptional(clusterId)) {
             logger.warn(
                     "ZigBeeEndpoint with DeviceId={} of Home Automation profile " +
-                            "implements the OPTINAL cluster {} ONLY AS OUTPUT instead of input " +
+                            "implements the OPTIONAL cluster {} ONLY AS OUTPUT instead of input " +
                             "it may identify an error either on the Driver description or in " +
                             "in the implementation of firmware of the physical device",
                     endpoint.getDeviceTypeId(), clusterId

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/ZigBeeApiConstants.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/ZigBeeApiConstants.java
@@ -131,7 +131,7 @@ public class ZigBeeApiConstants {
     public static final int DEVICE_ID_IASZONE = IAS_Zone.DEVICE_ID;
     public static final int DEVICE_ID_IAS_WARNING_DEVICE = IAS_Warning.DEVICE_ID;
 
-    public static String getDeviceName(int deviceID){
+    public static String getDeviceName(int deviceID) {
 
         try{
 
@@ -170,8 +170,6 @@ public class ZigBeeApiConstants {
             else if(id.equals(Integer.toHexString(CLUSTER_ID_ILLUMINANCE_LEVEL_SENSING)))
                 return IlluminanceLevelSensing.NAME;
 
-
-
             else return null;
         }
         catch(Exception ex){
@@ -179,7 +177,7 @@ public class ZigBeeApiConstants {
         }
     }
 
-    public static String getClusterName(int clusterID){
+    public static String getClusterName(int clusterID) {
 
         try{
             String id = Integer.toHexString(clusterID);

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/general/OnOffCluster.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/general/OnOffCluster.java
@@ -35,7 +35,7 @@ import org.bubblecloud.zigbee.api.cluster.impl.core.ZCLClusterBase;
 import org.bubblecloud.zigbee.api.cluster.impl.global.DefaultResponseImpl;
 
 /**
- * The OnOff Cluster provides attributes and commands for switching devices between ‘On’ and ‘Off’ states. 
+ * The OnOff Cluster provides attributes and commands for switching devices between 'On' and 'Off' states. 
  * @author <a href="mailto:stefano.lenzi@isti.cnr.it">Stefano "Kismet" Lenzi</a>
  * @author <a href="mailto:francesco.furfari@isti.cnr.it">Francesco Furfari</a>
  * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/NodeListener.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/NodeListener.java
@@ -1,0 +1,32 @@
+package org.bubblecloud.zigbee.network;
+
+/**
+ * Provides an interface to notify upper layers of changes to {@link ZigBeeNode nodes}.
+ */
+public interface NodeListener {
+
+	/**
+	 * Notification that a node has been added to the list of nodes maintained within the network.
+	 * <p>
+	 * This is called when a node is initially added, and before any discovery has occurred. The listener
+	 * can not assume that all information contained within the {@link ZigBeeNode} is complete since
+	 * discovery is still taking place.
+	 * @param node {@link ZigBeeNode}
+	 */
+    public void nodeAdded(final ZigBeeNode node);
+
+	/**
+	 * Notification that a new node has completed its endpoint and descriptor discovery. When this
+	 * notification is called, the listener can assume that all information contained within the
+	 * {@link ZigBeeNode} is complete.
+	 * @param node {@link ZigBeeNode}
+	 */
+    public void nodeDiscovered(final ZigBeeNode node);
+
+	/**
+	 * Notification that a node has been removed from the list of nodes maintained within the network.
+	 * @param node {@link ZigBeeNode}
+	 */
+    public void nodeRemoved(final ZigBeeNode node);
+
+}

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNode.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNode.java
@@ -28,9 +28,11 @@ package org.bubblecloud.zigbee.network;
  * using the ZigBee protocol.
  * <p>
  * Each physical may contain up 240 endpoints which are represented by the {@link ZigBeeEndpoint}
- * class. Each endpoint is identified by an <i>EndPoint</i> address, but shares either the:<br>
- * - <i>64-bit 802.15.4 IEEE Address</i><br>
- * - <i>16-bit ZigBee Network Address</i><br>
+ * class. Each endpoint is identified by an <i>EndPoint</i> address, but shares either the:
+ * <ul>
+ * <li>64-bit 802.15.4 IEEE Address</li>
+ * <li>16-bit ZigBee Network Address</li>
+ * </ul>
  * <p>
  * The node descriptors are also available through the node. These provide basic information
  * about the device itself and are only available in the node (ie they are the same for all
@@ -45,11 +47,13 @@ package org.bubblecloud.zigbee.network;
 public interface ZigBeeNode {
 
     /**
+     * Gets the network address for this node
      * @return int representing the current network address linked to the node
      */
     public int getNetworkAddress();
 
     /**
+     * Gets the 64 bit IEEE address for this node
      * @return a {@link String} representing the IEEEAddress of the node
      */
     public String getIeeeAddress();

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodeDescriptor.java
@@ -145,7 +145,7 @@ public class ZigBeeNodeDescriptor {
 		return maximumBufferSize;
 	}
 
-	/*
+	/**
 	 * The maximum transfer size field of the node descriptor is sixteen bits in
 	 * length, with a valid range of 0x0000-0x7fff. This field specifies the
 	 * maximum size, in octets, of the application sub-layer data unit (ASDU)
@@ -159,7 +159,7 @@ public class ZigBeeNodeDescriptor {
 		return maximumTransferSize;
 	}
 
-	/*
+	/**
 	 * The MAC capability flags field is eight bits in length and specifies the
 	 * node capabilities, as required by the IEEE 802.15.4-2003 MAC sub-layer.
 	 * 
@@ -192,7 +192,7 @@ public class ZigBeeNodeDescriptor {
 		return macCapabilities;
 	}
 
-	/*
+	/**
 	 * The server mask field of the node descriptor is sixteen bits in length,
 	 * with bit settings signifying the system server capabilities of this node.
 	 * It is used to facilitate discovery of particular system servers by other

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodePowerDescriptor.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/ZigBeeNodePowerDescriptor.java
@@ -13,6 +13,13 @@ import org.bubblecloud.zigbee.network.packet.zdo.ZDO_POWER_DESC_RSP;
  * The node power descriptor gives a dynamic indication of the power status of
  * the node and is mandatory for each node.
  * <p>
+ * <ul>
+ * <li>powerMode</li>
+ * <li>powerSourcesAvailable</li>
+ * <li>powerSource</li>
+ * <li>powerLevel</li>
+ * </ul>
+ * <p>
  * The power descriptor may be requested during service discovery to gain information
  * about the device. 
  * <p>
@@ -108,7 +115,7 @@ public class ZigBeeNodePowerDescriptor {
 		}
 	}
 
-	/*
+	/**
 	 * The current power mode field of the node power descriptor is four bits in
 	 * length and specifies the current sleep/power-saving mode of the node.
 	 * @return {@link POWER_MODE}
@@ -117,7 +124,7 @@ public class ZigBeeNodePowerDescriptor {
 		return powerMode;
 	}
 
-	/*
+	/**
 	 * The available power sources field of the node power descriptor is four
 	 * bits in length and specifies the power sources available on this node.
 	 * For each power source supported on this node, the corresponding bit of
@@ -129,7 +136,7 @@ public class ZigBeeNodePowerDescriptor {
 		return powerSourcesAvailable;
 	}
 
-	/*
+	/**
 	 * The current power source field of the node power descriptor is four bits
 	 * in length and specifies the current power source being utilized by the
 	 * node. For the current power source selected, the corresponding bit of the
@@ -141,7 +148,7 @@ public class ZigBeeNodePowerDescriptor {
 		return powerSource;
 	}
 
-	/*
+	/**
 	 * The current power source level field of the node power descriptor is four
 	 * bits in length and specifies the level of charge of the power source. The
 	 * current power source level field shall be set to one of the non-reserved

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
@@ -233,6 +233,7 @@ public class EndpointBuilder implements Stoppable {
             // Get a list of supported endpoints
             correctlyInspected = inspectEndpointOfNode(nwk, node);
             if (correctlyInspected) {
+            	network.notifyNodeDiscovered(node);
                 return;
             } else {
                 // If you don't remove node with devices not yet inspected from network, you won't be able to re-inspect them later

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
@@ -251,7 +251,7 @@ public class EndpointBuilder implements Stoppable {
                 node.setNetworkAddress(nwk);
 
                 // Notify listeners that the device has been updated
-                for (final ZigBeeEndpoint endpoint : network.getEndPoints(node)) {
+                for (final ZigBeeEndpoint endpoint : network.getEndpoints(node)) {
                     network.notifyEndpointUpdated(endpoint);
                 }
             }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNetwork.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNetwork.java
@@ -213,6 +213,12 @@ public class ZigBeeNetwork {
         return result;
     }
 
+    /**
+     * Checks a node to see if it contains the specified endpoint
+     * @param ieee the IEEE address of the node
+     * @param endPoint the endpoint number
+     * @return true if the endpoint exists within the node
+     */
     public boolean containsEndpoint(String ieee, short endPoint) {
         final ZigBeeNode node = nodes.get(ieee);
         if (node == null) {
@@ -229,11 +235,21 @@ public class ZigBeeNetwork {
         return endPoints.containsKey(endPoint);
     }
 
+    /**
+     * Gets the {@link ZigBeeNode} for the specified address
+     * @param ieeeAddress 
+     * @return the {@link ZigBeeNode} or null if the node was not found
+     */
     public ZigBeeNodeImpl getNode(String ieeeAddress) {
         return nodes.get(ieeeAddress);
     }
 
-    public List<ZigBeeEndpoint> getEndPoints(final ZigBeeNode node) {
+    /**
+     * Returns a list of all the endpoints within the specified {@link ZigBeeNode}
+     * @param node the {@link ZigBeeNode}
+     * @return a {@link List} of {@link ZigBeeEndpoint endpoints}
+     */
+    public List<ZigBeeEndpoint> getEndpoints(final ZigBeeNode node) {
         return new ArrayList(devices.get(node).values());
     }
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNetwork.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNetwork.java
@@ -23,6 +23,7 @@
 package org.bubblecloud.zigbee.network.impl;
 
 import org.bubblecloud.zigbee.network.EndpointListener;
+import org.bubblecloud.zigbee.network.NodeListener;
 import org.bubblecloud.zigbee.network.ZigBeeDiscoveryMonitor;
 import org.bubblecloud.zigbee.network.ZigBeeEndpoint;
 import org.bubblecloud.zigbee.network.ZigBeeNode;
@@ -53,6 +54,7 @@ public class ZigBeeNetwork {
 
     private final List<ZigBeeDiscoveryMonitor> discoveryMonitors = new ArrayList<ZigBeeDiscoveryMonitor>();
 
+    private final List<NodeListener> nodeListeners = new ArrayList<NodeListener>();
     private final List<EndpointListener> endpointListeners = new ArrayList<EndpointListener>();
 
     /**
@@ -65,7 +67,7 @@ public class ZigBeeNetwork {
     }
     
     /**
-     * Gets the list of devices
+     * Gets the list of nodes
      * @return {@link HashTable} of nodes on the network
      */
     public Hashtable<String, ZigBeeNodeImpl> getNodes() {
@@ -81,15 +83,18 @@ public class ZigBeeNetwork {
      * <li><a href="http://zb4osgi.aaloa.org/redmine/issues/64">Base Driver should monitor the health status of device (#64)</a></li>
      * </ul>
      *
-     * @param node
+     * @param node {@link ZigBeeNode}
      * @return true if the node was removed
      */
     public synchronized boolean removeNode(ZigBeeNode node) {
         final String ieee = node.getIeeeAddress();
 
+        // Check that we have a node with the specified address
         if (!nodes.containsKey(ieee)) {
             return false;
         }
+        
+        // Remove the endpoints for this node
         HashMap<Integer, ZigBeeEndpoint> toRemove = devices.get(node);
         if (toRemove != null) {
             Iterator<ZigBeeEndpoint> it = toRemove.values().iterator();
@@ -102,6 +107,11 @@ public class ZigBeeNetwork {
                 }
             }
         }
+        
+        // Notify the listeners
+        notifyNodeRemoved(node);
+        
+        // Remove the node
         nodes.remove(ieee);
         return true;
     }
@@ -117,11 +127,11 @@ public class ZigBeeNetwork {
         logger.debug("Adding node {} to the network", node);
         nodes.put(ieee, node);
         devices.put(node, new HashMap<Integer, ZigBeeEndpoint>());
+        notifyNodeAdded(node);
         return true;
     }
 
     public synchronized boolean removeEndpoint(ZigBeeEndpoint endpoint) {
-
         notifyEndpointRemoved(endpoint);
 
         final String ieee = endpoint.getNode().getIeeeAddress();
@@ -275,15 +285,24 @@ public class ZigBeeNetwork {
         }
     }
 
-    public void addEndpointListener(final EndpointListener deviceListener) {
+    /**
+     * Add an endpoint listener. The listener will be called when endpoints are added
+     * removed or updated.
+     * @param endpointListener
+     */
+    public void addEndpointListener(final EndpointListener endpointListener) {
         synchronized (endpointListeners) {
-            endpointListeners.add(deviceListener);
+            endpointListeners.add(endpointListener);
         }
     }
 
-    public void removeEndpointListener(final EndpointListener deviceListener) {
+    /**
+     * Remove a previously registered endpoint listener.
+     * @param endpointListener
+     */
+    public void removeEndpointListener(final EndpointListener endpointListener) {
         synchronized (endpointListeners) {
-            endpointListeners.remove(deviceListener);
+            endpointListeners.remove(endpointListener);
         }
     }
 
@@ -307,6 +326,69 @@ public class ZigBeeNetwork {
         synchronized (endpointListeners) {
             for (final EndpointListener endpointListener : endpointListeners) {
                 endpointListener.endpointRemoved(endpoint);
+            }
+        }
+    }
+
+    /**
+     * Add an node listener. The listener will be called when a node is added
+     * removed or updated.
+     * @param nodeListener {@link NodeListener}
+     */
+    public void addNodeListener(final NodeListener nodeListener) {
+        synchronized (nodeListeners) {
+        	nodeListeners.add(nodeListener);
+        }
+    }
+
+    /**
+     * Remove a previously registered an node listener.
+     * @param nodeListener {@link NodeListener}
+     */
+    public void removeNodeListener(final NodeListener nodeListener) {
+        synchronized (nodeListeners) {
+        	nodeListeners.remove(nodeListener);
+        }
+    }
+    
+    /**
+     * Notifies node listeners that a node has been added to the list of nodes.
+     * This is called when the node is first found, and before endpoints have been added
+     * or descriptors scanned.
+     *
+     * @param node the {@link ZigBeeNode}
+     */
+    public void notifyNodeAdded(final ZigBeeNode node) {
+        synchronized (discoveryMonitors) {
+            for (final NodeListener nodeListener : nodeListeners) {
+                nodeListener.nodeDiscovered(node);
+            }
+        }
+    }
+
+    /**
+     * Notifies node listeners that node discovery has been completed.
+     * This is called after all endpoints have been added.
+     *
+     * @param node the {@link ZigBeeNode}
+     */
+    public void notifyNodeDiscovered(final ZigBeeNode node) {
+        synchronized (discoveryMonitors) {
+            for (final NodeListener nodeListener : nodeListeners) {
+                nodeListener.nodeDiscovered(node);
+            }
+        }
+    }
+
+    /**
+     * Notifies node listeners that a node has been removed from the list of nodes.
+     *
+     * @param node the {@link ZigBeeNode}
+     */
+    public void notifyNodeRemoved(final ZigBeeNode node) {
+        synchronized (discoveryMonitors) {
+            for (final NodeListener nodeListener : nodeListeners) {
+                nodeListener.nodeDiscovered(node);
             }
         }
     }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_TC_DEVICE_IND.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/zdo/ZDO_TC_DEVICE_IND.java
@@ -35,23 +35,29 @@ import org.bubblecloud.zigbee.util.DoubleByte;
  * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2015-03-15 19:00:05 +0300 (Sun, 15 Mar 2015) $)
  */
 public class ZDO_TC_DEVICE_IND extends ZToolPacket /*implements IRESPONSE_CALLBACK,IZDO*/ {
-    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND.IEEEAddr</name>
-    /// <summary>64 bit IEEE address of source device</summary>
+    /**
+     * 64 bit IEEE address of source device
+     */
     public ZToolAddress64 IEEEAddr;
-    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND.NwkAddr</name>
-    /// <summary>Network address</summary>
+    /**
+     * Network address
+     */
     public ZToolAddress16 NwkAddr;
-    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND.SrcAddr</name>
-    /// <summary>Source address</summary>
+    /**
+     * Source address
+     */
     public ZToolAddress16 SrcAddr;
 
-    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND</name>
-    /// <summary>Constructor</summary>
+    /**
+     * Constructor
+     */
     public ZDO_TC_DEVICE_IND() {
     }
 
-    /// <name>TI.ZPI2.ZDO_TC_DEVICE_IND</name>
-    /// <summary>Constructor</summary>
+    /**
+     * Constructor
+     * @param framedata
+     */
     public ZDO_TC_DEVICE_IND(int[] framedata) {
         this.SrcAddr = new ZToolAddress16(framedata[1], framedata[0]);
         byte[] bytes = new byte[8];

--- a/zigbee-api/src/test/java/org/bubblecloud/zigbee/network/impl/NetworkStateSerializerTest.java
+++ b/zigbee-api/src/test/java/org/bubblecloud/zigbee/network/impl/NetworkStateSerializerTest.java
@@ -42,7 +42,7 @@ public class NetworkStateSerializerTest {
         networkStateSerializer.deserialize(null, zigBeeNetworkRestored, networkState);
 
         Assert.assertEquals(1, zigBeeNetworkRestored.getDevices().size());
-        Assert.assertEquals(1, zigBeeNetworkRestored.getEndPoints(
+        Assert.assertEquals(1, zigBeeNetworkRestored.getEndpoints(
                 zigBeeNetworkRestored.getDevices().keySet().iterator().next()).size());
 
         final String networkStateOfRestoredNetwork = networkStateSerializer.serialize(zigBeeNetworkRestored);

--- a/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -13,6 +13,7 @@ import org.bubblecloud.zigbee.api.cluster.impl.api.core.ReportListener;
 import org.bubblecloud.zigbee.api.cluster.impl.api.core.Reporter;
 import org.bubblecloud.zigbee.api.cluster.impl.api.core.ZigBeeClusterException;
 import org.bubblecloud.zigbee.api.cluster.general.ColorControl;
+import org.bubblecloud.zigbee.network.NodeListener;
 import org.bubblecloud.zigbee.network.ZigBeeNode;
 import org.bubblecloud.zigbee.network.ZigBeeNodeDescriptor;
 import org.bubblecloud.zigbee.network.ZigBeeNodePowerDescriptor;
@@ -129,6 +130,23 @@ public final class ZigBeeConsole {
             public void deviceRemoved(Device device) {
                 print("Device removed: " + device.getEndpointId() + " (#" + device.getNetworkAddress() + ")");
             }
+        });
+
+        zigbeeApi.addNodeListener(new NodeListener() {
+			@Override
+			public void nodeAdded(ZigBeeNode node) {
+                print("Node added: " + node.getIeeeAddress() + " (#" + node.getNetworkAddress() + ")");
+			}
+
+			@Override
+			public void nodeDiscovered(ZigBeeNode node) {
+                print("Node discovered: " + node.getIeeeAddress() + " (#" + node.getNetworkAddress() + ")");
+			}
+
+			@Override
+			public void nodeRemoved(ZigBeeNode node) {
+                print("Node removed: " + node.getIeeeAddress() + " (#" + node.getNetworkAddress() + ")");
+			}
         });
 
         Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {


### PR DESCRIPTION
This allows discovery in higher layers to be based on a node being added, rather than endpoints. The ```nodeDiscovered``` notification gets called after all endpoints have been added, so the higher layer can be sure the device discovery is complete.