### PR TITLE
getCurrentChannel() should wait until the network is ready.

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/simple/ZB_WRITE_CONFIGURATION.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/simple/ZB_WRITE_CONFIGURATION.java
@@ -49,7 +49,7 @@ public class ZB_WRITE_CONFIGURATION extends ZToolPacket/* implements IREQUEST,IS
         public static final int ZCD_NV_STARTUP_OPTION = 0x03;
         public static final int ZCD_NV_LOGICAL_TYPE = 0x87;
         public static final int ZCD_NV_POLL_RATE = 0x24;
-        public static final int ZCD_NV_QEUED_POL_RATE = 0x25;
+        public static final int ZCD_NV_QUEUED_POLL_RATE = 0x25;
         public static final int ZCD_NV_RESPONSE_POLL_RATE = 0x26;
         public static final int ZCD_NV_POLL_FAILURE_RETRIES = 0x29;
         public static final int ZCD_NV_INDIRECT_MSG_TIMEOUT = 0x2B;
@@ -66,6 +66,7 @@ public class ZB_WRITE_CONFIGURATION extends ZToolPacket/* implements IREQUEST,IS
         public static final int ZCD_NV_PASSIVE_ACK_TIMEOUT = 0x2F;
         public static final int ZCD_NV_BCAST_DELIVERY_TIME = 0x30;
         public static final int ZCD_NV_ROUTE_EXPIRY_TIME = 0x2C;
+        public static final int ZCD_NV_EXTPANID = 0x2D;
     }
 
 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -1327,7 +1327,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
      * @since 0.2.0
      */
     public int getCurrentChannel() {
-        if (waitForHardware() == false) {
+        if (waitForNetwork() == false) {
             logger.info("Failed to reach the {} level: getCurrentChannel() failed", DriverStatus.NETWORK_READY);
             return -1;
         }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -1317,7 +1317,8 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
         int[] result = getDeviceInfo(ZB_GET_DEVICE_INFO.DEV_INFO_TYPE.EXT_PAN_ID);
 
         if (result == null) {
-            return -1;
+        	 // luckily -1 (aka 0xffffffffffffffffL) is not a valid extended PAN ID value
+            return -1; 
         } else {
             return Integers.longFromInts(result, 7, 0);
         }

--- a/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -99,7 +99,7 @@ public final class ZigBeeConsole {
         final ZigBeeApi zigbeeApi = new ZigBeeApi(port, pan, channel, resetNetwork, discoveryModes);
 
         final File networkStateFile = new File("network.json");
-        if (networkStateFile.exists()) {
+        if (!resetNetwork && networkStateFile.exists()) {
             try {
                 final String networkState = FileUtils.readFileToString(networkStateFile);
                 zigbeeApi.deserializeNetworkState(networkState);

--- a/zigbee-console-javase/src/main/java/org/bubblecloud/zigbee/ZigBeeConsoleJavaSE.java
+++ b/zigbee-console-javase/src/main/java/org/bubblecloud/zigbee/ZigBeeConsoleJavaSE.java
@@ -20,7 +20,7 @@ public class ZigBeeConsoleJavaSE
 		try {
 			serialPortName = args[0];
 			channel        = Integer.parseInt(args[1]);
-			pan            = Integer.parseInt(args[2]);
+			pan            = parseDecimalOrHexInt(args[2]);			
 			resetNetwork   = args[3].equals("true");
 		} catch (final Throwable t) {
 			System.out.println("Syntax: java -jar zigbee4java-serialPort.jar SERIALPORT CHANNEL PAN RESET");
@@ -32,5 +32,15 @@ public class ZigBeeConsoleJavaSE
 		ZigBeeConsole console = new ZigBeeConsole(serialPort,pan,channel,resetNetwork);
 
 		console.start();
+	}
+	
+	private static int parseDecimalOrHexInt(String s) {
+		int radix = 10;
+		String number = s;
+		if (number.startsWith("0x")) {
+			number = number.substring(2);
+			radix = 16;
+		}
+		return Integer.parseInt(number, radix);
 	}
 }


### PR DESCRIPTION
Otherwise it might return 0 if the network is started resetting the state
and it's not yet ready.

ZigBee API starting up...17:26:30 224  DEBUG  Opening portIdentifier '/dev/ttyACM0'.
17:26:30 230  DEBUG  -> SYS_RESET (Packet: length = 1, apiId = 0x41 0x00, full data = 0xfe 0x01 0x41 0x00 0x01 0x41, checksum = 0x41, error = false, errorMessage = null) 
17:26:30 247  DEBUG  <-- ZDO_STATE_CHANGE_IND (ZDO_STATE_CHANGE_IND{State=DEV_ZB_COORD})
17:26:31 372  DEBUG  <-- SYS_RESET_RESPONSE (Packet: length = 6, apiId = 0x41 0x80, full data = 0xfe 0x06 0x41 0x80 0x00 0x02 0x00 0x02 0x06 0x03 0xc2, checksum = 0xc2, error = false, errorMessage = null)
17:26:31 373  DEBUG  Resetting network stack.
17:26:31 373  INFO   Setting clean state.
17:26:31 375  DEBUG  -> ZB_WRITE_CONFIGURATION (Packet: length = 3, apiId = 0x26 0x05, full data = 0xfe 0x03 0x26 0x05 0x03 0x01 0x02 0x20, checksum = 0x20, error = false, errorMessage = null) 
17:26:31 394  DEBUG  <- ZB_WRITE_CONFIGURATION_RSP (ZB_WRITE_CONFIGURATION_RSP{Status=SUCCESS(0)})
17:26:31 395  DEBUG  Setting channel to 11.
17:26:31 399  DEBUG  -> ZB_WRITE_CONFIGURATION (Packet: length = 6, apiId = 0x26 0x05, full data = 0xfe 0x06 0x26 0x05 0x84 0x04 0x00 0x08 0x00 0x00 0xad, checksum = 0xad, error = false, errorMessage = null) 
17:26:31 405  DEBUG  <- ZB_WRITE_CONFIGURATION_RSP (ZB_WRITE_CONFIGURATION_RSP{Status=SUCCESS(0)})
17:26:31 405  DEBUG  Setting PAN to 1234.
17:26:31 406  DEBUG  -> ZB_WRITE_CONFIGURATION (Packet: length = 4, apiId = 0x26 0x05, full data = 0xfe 0x04 0x26 0x05 0x83 0x02 0xd2 0x04 0x70, checksum = 0x70, error = false, errorMessage = null) 
17:26:31 420  DEBUG  <- ZB_WRITE_CONFIGURATION_RSP (ZB_WRITE_CONFIGURATION_RSP{Status=SUCCESS(0)})
17:26:31 420  DEBUG  Changing the Network Mode to Coordinator.
17:26:31 421  DEBUG  -> ZB_WRITE_CONFIGURATION (Packet: length = 3, apiId = 0x26 0x05, full data = 0xfe 0x03 0x26 0x05 0x87 0x01 0x00 0xa6, checksum = 0xa6, error = false, errorMessage = null) 
17:26:31 425  DEBUG  <- ZB_WRITE_CONFIGURATION_RSP (ZB_WRITE_CONFIGURATION_RSP{Status=SUCCESS(0)})
17:26:31 426  DEBUG  -> SYS_RESET (Packet: length = 1, apiId = 0x41 0x00, full data = 0xfe 0x01 0x41 0x00 0x01 0x41, checksum = 0x41, error = false, errorMessage = null) 
17:26:32 631  DEBUG  <-- SYS_RESET_RESPONSE (Packet: length = 6, apiId = 0x41 0x80, full data = 0xfe 0x06 0x41 0x80 0x00 0x02 0x00 0x02 0x06 0x03 0xc2, checksum = 0xc2, error = false, errorMessage = null)
17:26:32 632  DEBUG  -> ZB_WRITE_CONFIGURATION (Packet: length = 3, apiId = 0x26 0x05, full data = 0xfe 0x03 0x26 0x05 0x03 0x01 0x00 0x22, checksum = 0x22, error = false, errorMessage = null) 
17:26:32 645  DEBUG  <- ZB_WRITE_CONFIGURATION_RSP (ZB_WRITE_CONFIGURATION_RSP{Status=SUCCESS(0)})
17:26:32 646  DEBUG  Creating network as Coordinator
17:26:32 647  DEBUG  -> ZDO_MSG_CB_REGISTER (Packet: length = 2, apiId = 0x25 0x3e, full data = 0xfe 0x02 0x25 0x3e 0xff 0xff 0x19, checksum = 0x19, error = false, errorMessage = null) 
17:26:32 651  DEBUG  <- ZDO_MSG_CB_REGISTER_SRSP (ZDO_MSG_CB_REGISTER_SRSP{Status=SUCCESS(0)})
17:26:32 652  DEBUG  -> ZDO_STARTUP_FROM_APP (Packet: length = 2, apiId = 0x25 0x40, full data = 0xfe 0x02 0x25 0x40 0x00 0x00 0x67, checksum = 0x67, error = false, errorMessage = null) 
17:26:33 449  DEBUG  <- ZDO_STARTUP_FROM_APP_SRSP (ZDO_STARTUP_FROM_APP_SRSP{Status=FAILURE(1)})
17:26:33 449  INFO   Initialized ZigBee network with new or reset network state.
17:26:33 450  DEBUG  -> ZB_GET_DEVICE_INFO (Packet: length = 1, apiId = 0x26 0x06, full data = 0xfe 0x01 0x26 0x06 0x05 0x24, checksum = 0x24, error = false, errorMessage = null) 
17:26:33 451  DEBUG  <-- ZDO_STATE_CHANGE_IND (ZDO_STATE_CHANGE_IND{State=DEV_COORD_STARTING})
17:26:33 455  DEBUG  <- ZB_GET_DEVICE_INFO_RSP (Packet: length = 9, apiId = 0x66 0x06, full data = 0xfe 0x09 0x66 0x06 0x05 0x00 0xc0 0x08 0x8c 0x09 0x00 0x8a 0x10 0xbb, checksum = 0xbb, error = false, errorMessage = null)
17:26:33 455  WARN   The channel configuration differ from the channel configuration in use: in use 0, while the configured is 11.
The ZigBee network should be reconfigured or configuration corrected.
17:26:33 456  DEBUG  -> ZB_GET_DEVICE_INFO (Packet: length = 1, apiId = 0x26 0x06, full data = 0xfe 0x01 0x26 0x06 0x06 0x27, checksum = 0x27, error = false, errorMessage = null) 
17:26:33 461  DEBUG  <- ZB_GET_DEVICE_INFO_RSP (Packet: length = 9, apiId = 0x66 0x06, full data = 0xfe 0x09 0x66 0x06 0x06 0xd2 0x04 0x08 0x8c 0x09 0x00 0x8a 0x10 0xae, checksum = 0xae, error = false, errorMessage = null)
17:26:33 461  DEBUG  -> ZB_READ_CONFIGURATION (Packet: length = 1, apiId = 0x26 0x04, full data = 0xfe 0x01 0x26 0x04 0x87 0xa4, checksum = 0xa4, error = false, errorMessage = null) 
17:26:33 467  DEBUG  <- ZB_READ_CONFIGURATION_RSP (ZB_READ_CONFIGURATION_RSP{ConfigId=135, Len=1, Status=SUCCESS(0), Value=[0]})
17:26:33 468  ERROR  Dongle configuration does not match the specified configuration.
17:26:33 468  DEBUG  Serial portIdentifier '/dev/ttyACM0' closed.
17:26:33 568  WARN   Discarded stream: expected start byte but received this 0x00
17:26:33 568  DEBUG  ZToolPacketParser parserThread exited.

ZigBee API starting up ... [FAIL]
