### PR TITLE
Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,15 @@
                     </dependency>
                 </dependencies>
             </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>    
         </plugins>
         <extensions>
             <extension>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,12 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.5</version>
         </dependency>

--- a/zigbee-api/pom.xml
+++ b/zigbee-api/pom.xml
@@ -18,6 +18,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.5</version>
+                <configuration>
+                    <archive>  
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive> 
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -39,7 +44,65 @@
 					</execution>
 				</executions>
 			</plugin>
+			
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>    
+                            <goal>manifest</goal>
+                        </goals>   
+                    </execution>
+                </executions>
+                <configuration>
+                    <instructions>
+                        <!--SLF4J API is backward compatible down to version 1.0.
+                        See http://www.slf4j.org/faq.html.-->
+                        <Import-Package>org.slf4j;version="1.0", *</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
         </plugins>
+        
+        <pluginManagement>
+        	<plugins>
+        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        		<plugin>
+        			<groupId>org.eclipse.m2e</groupId>
+        			<artifactId>lifecycle-mapping</artifactId>
+        			<version>1.0.0</version>
+        			<configuration>
+        				<lifecycleMappingMetadata>
+        					<pluginExecutions>
+        						<pluginExecution>
+        							<pluginExecutionFilter>
+        								<groupId>
+        									org.apache.felix
+        								</groupId>
+        								<artifactId>
+        									maven-bundle-plugin
+        								</artifactId>
+        								<versionRange>
+        									[2.3.7,)
+        								</versionRange>
+        								<goals>
+        									<goal>manifest</goal>
+        								</goals>
+        							</pluginExecutionFilter>
+        							<action>
+        								<ignore></ignore>
+        							</action>
+        						</pluginExecution>
+        					</pluginExecutions>
+        				</lifecycleMappingMetadata>
+        			</configuration>
+        		</plugin>
+        	</plugins>
+        </pluginManagement>
     </build>
 
     <dependencies>

--- a/zigbee-api/pom.xml
+++ b/zigbee-api/pom.xml
@@ -63,6 +63,22 @@
                         <!--SLF4J API is backward compatible down to version 1.0.
                         See http://www.slf4j.org/faq.html.-->
                         <Import-Package>org.slf4j;version="1.0", *</Import-Package>
+                        <!-- Include "impl" packages in the bundle -->
+                        <Private-Package>
+                            org.bubblecloud.zigbee.api.cluster.impl,
+                            org.bubblecloud.zigbee.api.cluster.impl.*,
+                            org.bubblecloud.zigbee.network.impl,
+                            org.bubblecloud.zigbee.api.device.impl
+                        </Private-Package>
+                        <!-- By default "impl" packages are not added to the "Export-Package" 
+                        header of the MANIFEST -->
+                        <Export-Package>
+                            {local-packages},
+                            org.bubblecloud.zigbee.api.cluster.impl,
+                            org.bubblecloud.zigbee.api.cluster.impl.*,
+                            org.bubblecloud.zigbee.network.impl,
+                            org.bubblecloud.zigbee.api.device.impl
+                        </Export-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Minor fixes for the Maven build:
- Importing javase projects in Eclipse as Maven Projects results in errors in the workspace. For example:

The method endpointRemoved(ZigBeeEndpoint) of type ZigBeeApi must override a superclass method

Quick fix: Remove @Override annotation

The @Override annotation was introduced in Java 6 but for some reason Eclipse is configured with compiler source and target levels set to 1.5.

- The slf4j-api should be listed as a Maven dependency. I added this only to the Maven build.

- Add instructions to the zigbee-api Maven build to add the OSGi headers to the MANIFEST of the jar artifact. In this way the zigbee-api jar can be immediately consumed as an OSGi bundle.  