### PR TITLE
Fix issue #76.

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeInterface.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeInterface.java
@@ -155,17 +155,7 @@ public class ZigBeeInterface implements ZToolPacketHandler {
             throws IOException {
         LOGGER.debug("-> {} ({}) ", packet.getClass().getSimpleName(), packet.toString());
         final int[] pck = packet.getPacket();
-        synchronized (port) {
-            final OutputStream out = port.getOutputStream();
-            if (out == null) {
-                // Socket has not been opened or is already closed.
-                return;
-            }
-            for (int i = 0; i < pck.length; i++) {
-                out.write(pck[i]);
-            }
-            out.flush();
-        }
+        sendRaw(pck);
     }
 
 
@@ -268,6 +258,20 @@ public class ZigBeeInterface implements ZToolPacketHandler {
             );
         }
         sendPacket(packet);
+    }
+    
+    public void sendRaw(int[] buffer) throws IOException {
+        synchronized (port) {
+            final OutputStream out = port.getOutputStream();
+            if (out == null) {
+                // Socket has not been opened or is already closed.
+                return;
+            }
+            for (int i = 0; i < buffer.length; i++) {
+                out.write(buffer[i]);
+            }
+            out.flush();
+        }
     }
 
     /**

--- a/zigbee-serial-javase/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeSerialPortImpl.java
+++ b/zigbee-serial-javase/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeSerialPortImpl.java
@@ -47,10 +47,6 @@ public class ZigBeeSerialPortImpl implements ZigBeePort
         try {
             openSerialPort(portIdentifier, 0, baudRate, 8, SerialComm.ONE_STOP_BIT,
                     SerialComm.NO_PARITY, SerialComm.FLOW_CONTROL_DISABLED);
-            
-            // Write the 'magic byte'
-            // Note that this might change in future, or with different dongles
-            outputStream.write(0xef);
 
             return true;
         } catch (Exception e) {


### PR DESCRIPTION
Note that this commit reverts RESET_TIMEOUT_DEFAULT to 5s.
First an attempt is made to reset the dongle.
If timeout occurs we assume that the bootloader is
running and we send the magic byte waiting for a
SYS_RESET_RESPONSE.
The magic byte is 0xef by default and configurable
through a new zigbee.driver.cc2530.bl.magic.byte
system property.