### PR TITLE
Code quality fix - Collection.isEmpty() should be used to test for emptiness.

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/ReporterBase.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/ReporterBase.java
@@ -246,7 +246,7 @@ public abstract class ReporterBase implements Reporter {
      */
     public boolean isActive() {
         synchronized (listeners) {
-            return listeners.size() == 0;
+            return listeners.isEmpty();
         }
     }
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/CurrentLevelBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/CurrentLevelBridgeListeners.java
@@ -93,7 +93,7 @@ public class CurrentLevelBridgeListeners implements ReportListener {
 
     public boolean subscribe(CurrentLevelListener listener) {
         synchronized (listeners) {
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 AnalogReporter reporter = (AnalogReporter) bridged.getReporter();
                 if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
@@ -112,7 +112,7 @@ public class CurrentLevelBridgeListeners implements ReportListener {
     public boolean unsubscribe(CurrentLevelListener listener) {
         synchronized (listeners) {
             listeners.remove(listener);
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 Reporter reporter = bridged.getReporter();
                 if (reporter.getReportListenersCount() == 1) {
                     reporter.clear();

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/MeasuredValueBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/MeasuredValueBridgeListeners.java
@@ -115,7 +115,7 @@ public class MeasuredValueBridgeListeners implements ReportListener {
      */
     public boolean subscribe(MeasuredValueListener listener) {
         synchronized (listeners) {
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 AnalogReporter reporter = (AnalogReporter) bridged.getReporter();
                 if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
@@ -134,7 +134,7 @@ public class MeasuredValueBridgeListeners implements ReportListener {
     public boolean unsubscribe(MeasuredValueListener listener) {
         synchronized (listeners) {
             listeners.remove(listener);
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 Reporter reporter = bridged.getReporter();
                 if (reporter.getReportListenersCount() == 1) {
                     reporter.clear();

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/OccupancyBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/OccupancyBridgeListeners.java
@@ -91,7 +91,7 @@ public class OccupancyBridgeListeners implements ReportListener {
 
     public boolean subscribe(OccupancyListener listener) {
         synchronized (listeners) {
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 Reporter reporter = bridged.getReporter();
                 if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
@@ -109,7 +109,7 @@ public class OccupancyBridgeListeners implements ReportListener {
     public boolean unsubscribe(OccupancyListener listener) {
         synchronized (listeners) {
             listeners.remove(listener);
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 Reporter reporter = bridged.getReporter();
                 if (reporter.getReportListenersCount() == 1) {
                     reporter.clear();

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/OnOffBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/OnOffBridgeListeners.java
@@ -92,7 +92,7 @@ public class OnOffBridgeListeners implements ReportListener {
 
     public boolean subscribe(OnOffListener listener) {
         synchronized (listeners) {
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 Reporter reporter = bridged.getReporter();
                 if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
@@ -110,7 +110,7 @@ public class OnOffBridgeListeners implements ReportListener {
     public boolean unsubscribe(OnOffListener listener) {
         synchronized (listeners) {
             listeners.remove(listener);
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 Reporter reporter = bridged.getReporter();
                 if (reporter.getReportListenersCount() == 1) {
                     reporter.clear();

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/PresentValueBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/PresentValueBridgeListeners.java
@@ -89,7 +89,7 @@ public class PresentValueBridgeListeners implements ReportListener {
 
     public boolean subscribe(PresentValueListener listener) {
         synchronized (listeners) {
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 Reporter reporter = bridged.getReporter();
                 if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
@@ -107,7 +107,7 @@ public class PresentValueBridgeListeners implements ReportListener {
     public boolean unsubscribe(PresentValueListener listener) {
         synchronized (listeners) {
             listeners.remove(listener);
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 Reporter reporter = bridged.getReporter();
                 if (reporter.getReportListenersCount() == 1) {
                     reporter.clear();

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/ToleranceBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/ToleranceBridgeListeners.java
@@ -92,7 +92,7 @@ public class ToleranceBridgeListeners implements ReportListener {
 
     public boolean subscribe(ToleranceListener listener) {
         synchronized (listeners) {
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 AnalogReporter reporter = (AnalogReporter) bridged.getReporter();
                 if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
@@ -111,7 +111,7 @@ public class ToleranceBridgeListeners implements ReportListener {
     public boolean unsubscribe(ToleranceListener listener) {
         synchronized (listeners) {
             listeners.remove(listener);
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 Reporter reporter = bridged.getReporter();
                 if (reporter.getReportListenersCount() == 1) {
                     reporter.clear();

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/general/AlarmsCluster.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/general/AlarmsCluster.java
@@ -146,7 +146,7 @@ public class AlarmsCluster extends ZCLClusterBase implements Alarms {
 
     public boolean addAlarmListerner(AlarmListener listener) {
         synchronized (listeners) {
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 try {
                     getZigBeeEndpoint().bindToLocal(ID);
                 } catch (ZigBeeNetworkManagerException e) {
@@ -166,7 +166,7 @@ public class AlarmsCluster extends ZCLClusterBase implements Alarms {
     public boolean removeAlarmListerner(AlarmListener listener) {
         synchronized (listeners) {
             boolean removed = listeners.remove(listener);
-            if (listeners.size() == 0 && removed) {
+            if (listeners.isEmpty() && removed) {
                 try {
                     getZigBeeEndpoint().unbindFromLocal(ID);
                 } catch (ZigBeeNetworkManagerException e) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/security_safety/IASZoneCluster.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/security_safety/IASZoneCluster.java
@@ -139,7 +139,7 @@ public class IASZoneCluster extends ZCLClusterBase implements IASZone {
 
     public boolean addZoneStatusChangeNotificationListener(ZoneStatusChangeNotificationListener listener) {
         synchronized (listeners) {
-            if (listeners.size() == 0) {
+            if (listeners.isEmpty()) {
                 try {
                     getZigBeeEndpoint().bindToLocal(ID);
                 } catch (ZigBeeNetworkManagerException e) {
@@ -159,7 +159,7 @@ public class IASZoneCluster extends ZCLClusterBase implements IASZone {
     public boolean removeZoneStatusChangeNotificationListener(ZoneStatusChangeNotificationListener listener) {
         synchronized (listeners) {
             boolean removed = listeners.remove(listener);
-            if (listeners.size() == 0 && removed) {
+            if (listeners.isEmpty() && removed) {
                 try {
                     getZigBeeEndpoint().unbindFromLocal(ID);
                 } catch (ZigBeeNetworkManagerException e) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/AssociationNetworkBrowser.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/AssociationNetworkBrowser.java
@@ -101,7 +101,7 @@ public class AssociationNetworkBrowser extends RunnableThread {
             logger.debug("Inspecting ZigBee network for new nodes.");
             toInspect.add(new NetworkAddressNodeItem(null, COORDINATOR_NWK_ADDRESS));
             try {
-                while (toInspect.size() != 0) {
+                while (!toInspect.isEmpty()) {
                     final NetworkAddressNodeItem inspecting = toInspect.remove(toInspect.size() - 1);
 
                     alreadyInspected.put((int) inspecting.address, inspecting);

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/EndpointBuilder.java
@@ -334,20 +334,20 @@ public class EndpointBuilder implements Stoppable {
                 logger.trace("Inspection queue: New queue size: {}. Failed queue size: {}", queue.size(), failedEndpoints.size());
 
                 // Prioritise new endpoints over re-inspecting failed endpoints
-                if (queue.size() > 0 && failedEndpoints.size() > 0) {
+                if (!queue.isEmpty() && !failedEndpoints.isEmpty()) {
                     // 2/3rds of the time, inspect new endpoints
                     if (Math.random() > 0.6) {
                         inspectFailedEndpoint();
                     } else {
                         inspectNewEndpoint();
                     }
-                } else if (queue.size() == 0 && failedEndpoints.size() > 0) {
+                } else if (queue.isEmpty() && !failedEndpoints.isEmpty()) {
                 	// There are no new endpoints, but failed endoints are queued
                     inspectFailedEndpoint();
-                } else if (queue.size() > 0 && failedEndpoints.size() == 0) {
+                } else if (!queue.isEmpty() && failedEndpoints.isEmpty()) {
                 	// There are no failed endpoints, but new endpoints are queued
                     inspectNewEndpoint();
-                } else if (queue.size() == 0 && failedEndpoints.size() == 0) {
+                } else if (queue.isEmpty() && failedEndpoints.isEmpty()) {
                 	// There are no endpoints queued.........
                 	// Why is this here - queue size is 0?!?
                     inspectNewEndpoint();

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/ImportingQueue.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/discovery/ImportingQueue.java
@@ -95,7 +95,7 @@ public class ImportingQueue {
      */
     public boolean isEmpty() {
         synchronized (addresses) {
-            return addresses.size() == 0;
+            return addresses.isEmpty();
         }
     }
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeEndpointImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeEndpointImpl.java
@@ -505,7 +505,7 @@ public class ZigBeeEndpointImpl implements ZigBeeEndpoint, ApplicationFrameworkM
     }
 
     private void addAFMessageListener() {
-        if (listeners.isEmpty() && consumers.size() == 0) {
+        if (listeners.isEmpty() && consumers.isEmpty()) {
             logger.trace("Registered {} as {}", this, ApplicationFrameworkMessageListener.class.getName());
             networkManager.addAFMessageListener(this);
         } else {
@@ -518,7 +518,7 @@ public class ZigBeeEndpointImpl implements ZigBeeEndpoint, ApplicationFrameworkM
     }
 
     private void removeAFMessageListener() {
-        if (listeners.isEmpty() && consumers.size() == 0) {
+        if (listeners.isEmpty() && consumers.isEmpty()) {
             logger.trace("Unregistered {} as {}", this, ApplicationFrameworkMessageListener.class.getName());
             networkManager.removeAFMessageListener(this);
         } else {
@@ -547,7 +547,7 @@ public class ZigBeeEndpointImpl implements ZigBeeEndpoint, ApplicationFrameworkM
         synchronized (listeners) {
             localCopy = new ArrayList<ClusterListener>(listeners);
         }
-        if (localCopy.size() > 0) {
+        if (!localCopy.isEmpty()) {
             logger.trace("Notifying {} ClusterListener of {}", localCopy.size(), c.toString());
 
             for (ClusterListener listner : localCopy) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Faisal Hameed