### PR TITLE
Code quality fix - Literal boolean values should not be used in condition expressions.

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/AnalogReporterImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/AnalogReporterImpl.java
@@ -53,7 +53,7 @@ public class AnalogReporterImpl extends ReporterBase implements AnalogReporter {
     public AnalogReporterImpl(final ZigBeeEndpoint zb, final ZCLCluster c, final Attribute attrib) {
         super(zb, c, attrib);
         final ZigBeeType type = attrib.getZigBeeType();
-        if (type.isAnalog() == false) {
+        if (!type.isAnalog()) {
             throw new IllegalArgumentException(
                     "AnalogReporter applies only to Attribute with analog data type, " +
                             "the attribute " + attrib.getName() + " (" + attrib.getId() + ") of type " + type.toString() +

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/AttributeImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/AttributeImpl.java
@@ -94,7 +94,7 @@ public class AttributeImpl implements Attribute {
     }
 
     public void setValue(Object o) throws ZigBeeClusterException {
-        if (isWritable() == false) {
+        if (!isWritable()) {
             throw new ZigBeeClusterException(
                     "Trying to set the attribute " + getName() + "(" + getId() + ") that is Read Only"
             );
@@ -113,7 +113,7 @@ public class AttributeImpl implements Attribute {
      * @return the {@link Reporter}
      */
     public Reporter getReporter() {
-        if (isReportable() == false) {
+        if (!isReportable()) {
             return null;
         }
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/ReporterBase.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/ReporterBase.java
@@ -182,7 +182,7 @@ public abstract class ReporterBase implements Reporter {
      * Clears all listeners.
      */
     public void clear() {
-        if (doUnbindToDevice() == true) {
+        if (doUnbindToDevice()) {
             synchronized (listeners) {
                 listeners.clear();
             }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/CurrentLevelBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/CurrentLevelBridgeListeners.java
@@ -95,13 +95,13 @@ public class CurrentLevelBridgeListeners implements ReportListener {
         synchronized (listeners) {
             if (listeners.size() == 0) {
                 AnalogReporter reporter = (AnalogReporter) bridged.getReporter();
-                if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
+                if (configuration.getReportingOverwrite() || !reporter.isActive()) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
                     reporter.setMinimumReportingInterval(configuration.getReportingMinimum());
                     reporter.setReportableChange(configuration.getReportingChange());
                     reporter.updateConfiguration();
                 }
-                if (reporter.addReportListener(this, true) == false) {
+                if (!reporter.addReportListener(this, true)) {
                     return false;
                 }
             }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/MeasuredValueBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/MeasuredValueBridgeListeners.java
@@ -117,13 +117,13 @@ public class MeasuredValueBridgeListeners implements ReportListener {
         synchronized (listeners) {
             if (listeners.size() == 0) {
                 AnalogReporter reporter = (AnalogReporter) bridged.getReporter();
-                if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
+                if (configuration.getReportingOverwrite() || !reporter.isActive()) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
                     reporter.setMinimumReportingInterval(configuration.getReportingMinimum());
                     reporter.setReportableChange(configuration.getReportingChange());
                     reporter.updateConfiguration();
                 }
-                if (reporter.addReportListener(this, true) == false) {
+                if (!reporter.addReportListener(this, true)) {
                     return false;
                 }
             }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/OccupancyBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/OccupancyBridgeListeners.java
@@ -93,12 +93,12 @@ public class OccupancyBridgeListeners implements ReportListener {
         synchronized (listeners) {
             if (listeners.size() == 0) {
                 Reporter reporter = bridged.getReporter();
-                if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
+                if (configuration.getReportingOverwrite() || !reporter.isActive()) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
                     reporter.setMinimumReportingInterval(configuration.getReportingMinimum());
                     reporter.updateConfiguration();
                 }
-                if (reporter.addReportListener(this, true) == false) {
+                if (!reporter.addReportListener(this, true)) {
                     return false;
                 }
             }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/OnOffBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/OnOffBridgeListeners.java
@@ -94,12 +94,12 @@ public class OnOffBridgeListeners implements ReportListener {
         synchronized (listeners) {
             if (listeners.size() == 0) {
                 Reporter reporter = bridged.getReporter();
-                if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
+                if (configuration.getReportingOverwrite() || !reporter.isActive()) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
                     reporter.setMinimumReportingInterval(configuration.getReportingMinimum());
                     reporter.updateConfiguration();
                 }
-                if (reporter.addReportListener(this, true) == false) {
+                if (!reporter.addReportListener(this, true)) {
                     return false;
                 }
             }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/PresentValueBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/PresentValueBridgeListeners.java
@@ -91,12 +91,12 @@ public class PresentValueBridgeListeners implements ReportListener {
         synchronized (listeners) {
             if (listeners.size() == 0) {
                 Reporter reporter = bridged.getReporter();
-                if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
+                if (configuration.getReportingOverwrite() || !reporter.isActive()) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
                     reporter.setMinimumReportingInterval(configuration.getReportingMinimum());
                     reporter.updateConfiguration();
                 }
-                if (reporter.addReportListener(this, true) == false) {
+                if (!reporter.addReportListener(this, true)) {
                     return false;
                 }
             }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/ToleranceBridgeListeners.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/event/ToleranceBridgeListeners.java
@@ -94,13 +94,13 @@ public class ToleranceBridgeListeners implements ReportListener {
         synchronized (listeners) {
             if (listeners.size() == 0) {
                 AnalogReporter reporter = (AnalogReporter) bridged.getReporter();
-                if (configuration.getReportingOverwrite() || reporter.isActive() == false) {
+                if (configuration.getReportingOverwrite() || !reporter.isActive()) {
                     reporter.setMaximumReportingInterval(configuration.getReportingMaximum());
                     reporter.setMinimumReportingInterval(configuration.getReportingMinimum());
                     reporter.setReportableChange(configuration.getReportingChange());
                     reporter.updateConfiguration();
                 }
-                if (reporter.addReportListener(this, true) == false) {
+                if (!reporter.addReportListener(this, true)) {
                     return false;
                 }
             }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/general/AlarmsCluster.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/general/AlarmsCluster.java
@@ -153,7 +153,7 @@ public class AlarmsCluster extends ZCLClusterBase implements Alarms {
                     log.error("Unable to bind to device for Alarms reporting", e);
                     return false;
                 }
-                if (getZigBeeEndpoint().addClusterListener(bridge) == false) {
+                if (!getZigBeeEndpoint().addClusterListener(bridge)) {
                     log.error("Unable to register the cluster listener for Alarms reporting");
                     return false;
                 }
@@ -173,7 +173,7 @@ public class AlarmsCluster extends ZCLClusterBase implements Alarms {
                     log.error("Unable to unbind to device for Alarms reporting", e);
                     return false;
                 }
-                if (getZigBeeEndpoint().removeClusterListener(bridge) == false) {
+                if (!getZigBeeEndpoint().removeClusterListener(bridge)) {
                     log.error("Unable to unregister the cluster listener for Alarms reporting");
                     return false;
                 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/global/reporting/ConfigureReportingCommand.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/global/reporting/ConfigureReportingCommand.java
@@ -59,7 +59,7 @@ public class ConfigureReportingCommand extends AbstractCommand {
                     //CASE OF ATTRIBUTE CONFIGURATION SENT TO CLIENT
                     //Size of: Direction + Attribute Id + Timeout
                     length += 1 + 2 + 2;
-                } else if (attributerecord[i].getAttributeDataType().isAnalog() == false) {
+                } else if (!attributerecord[i].getAttributeDataType().isAnalog()) {
                     //CASE OF ATTRIBUTE CONFIGURATION SENT TO SERVER OF A DISCRETE ATTRIBUTE
                     //Size of: Direction + Attribute Id + Data Type + Minimum + Maxium
                     length += 1 + 2 + 1 + 2 + 2;
@@ -80,7 +80,7 @@ public class ConfigureReportingCommand extends AbstractCommand {
                     serializer.append_byte((byte) attributerecord[i].getDiretion());
                     serializer.append_short((short) attributerecord[i].getAttributeId());
                     serializer.append_short((short) attributerecord[i].getTimeoutPeriod());
-                } else if (attributerecord[i].getAttributeDataType().isAnalog() == false) {
+                } else if (!attributerecord[i].getAttributeDataType().isAnalog()) {
                     //CASE OF ATTRIBUTE CONFIGURATION SENT TO SERVER OF A DISCRETE ATTRIBUTE
                     //Size of: Direction + Attribute Id + Data Type + Minimum + Maxium
                     serializer.append_byte((byte) attributerecord[i].getDiretion());

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/security_safety/IASZoneCluster.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/security_safety/IASZoneCluster.java
@@ -146,7 +146,7 @@ public class IASZoneCluster extends ZCLClusterBase implements IASZone {
                     log.error("Unable to bind to device for IASZone reporting", e);
                     return false;
                 }
-                if (getZigBeeEndpoint().addClusterListener(bridge) == false) {
+                if (!getZigBeeEndpoint().addClusterListener(bridge)) {
                     log.error("Unable to register the cluster listener for IASZone reporting");
                     return false;
                 }
@@ -166,7 +166,7 @@ public class IASZoneCluster extends ZCLClusterBase implements IASZone {
                     log.error("Unable to unbind to device for IASZone reporting", e);
                     return false;
                 }
-                if (getZigBeeEndpoint().removeClusterListener(bridge) == false) {
+                if (!getZigBeeEndpoint().removeClusterListener(bridge)) {
                     log.error("Unable to unregister the cluster listener for IASZone reporting");
                     return false;
                 }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeEndpointImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeEndpointImpl.java
@@ -555,7 +555,7 @@ public class ZigBeeEndpointImpl implements ZigBeeEndpoint, ApplicationFrameworkM
                     final ClusterFilter filter = listner.getClusterFilter();
                     if (filter == null) {
                         listner.handleCluster(this, c);
-                    } else if (filter.match(c) == true) {
+                    } else if (filter.match(c)) {
                         listner.handleCluster(this, c);
                     }
                 } catch (Throwable t) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNetwork.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeNetwork.java
@@ -194,7 +194,7 @@ public class ZigBeeNetwork {
             return true;
         }
         //XXX It following method must always return true, otherwise we should throw an IllegalStateException
-        if (list.remove(device) == false) {
+        if (!list.remove(device)) {
             logger.error("Device to remove not found in the given profile");
         }
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeInterface.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeInterface.java
@@ -232,7 +232,7 @@ public class ZigBeeInterface implements ZToolPacketHandler {
         } else {
             synchronized (synchronousCommandListeners) {
                 final short id = (short) (cmdId.get16BitValue() & 0x1FFF);
-                while (synchronousCommandListeners.isEmpty() == false) {
+                while (!synchronousCommandListeners.isEmpty()) {
                     try {
                         LOGGER.trace("Waiting for other request to complete");
                         synchronousCommandListeners.wait(500);

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -640,7 +640,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public <REQUEST extends ZToolPacket, RESPONSE extends ZToolPacket> RESPONSE sendLocalRequest(REQUEST request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         RESPONSE result = (RESPONSE) sendSynchrouns(zigbeeInterface, request);
@@ -651,7 +651,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public <REQUEST extends ZToolPacket, RESPONSE extends ZToolPacket> RESPONSE sendRemoteRequest(REQUEST request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         RESPONSE result = null;
@@ -675,7 +675,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
 
     public ZDO_MGMT_LQI_RSP sendLQIRequest(ZDO_MGMT_LQI_REQ request) {
 
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         ZDO_MGMT_LQI_RSP result = null;
@@ -696,7 +696,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public ZDO_IEEE_ADDR_RSP sendZDOIEEEAddressRequest(ZDO_IEEE_ADDR_REQ request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         ZDO_IEEE_ADDR_RSP result = null;
@@ -717,7 +717,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public ZDO_NODE_DESC_RSP sendZDONodeDescriptionRequest(ZDO_NODE_DESC_REQ request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         ZDO_NODE_DESC_RSP result = null;
@@ -737,7 +737,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public ZDO_POWER_DESC_RSP sendZDOPowerDescriptionRequest(ZDO_POWER_DESC_REQ request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         ZDO_POWER_DESC_RSP result = null;
@@ -757,7 +757,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public ZDO_ACTIVE_EP_RSP sendZDOActiveEndPointRequest(ZDO_ACTIVE_EP_REQ request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         ZDO_ACTIVE_EP_RSP result = null;
@@ -778,7 +778,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public ZDO_MGMT_PERMIT_JOIN_RSP sendPermitJoinRequest(ZDO_MGMT_PERMIT_JOIN_REQ request, boolean waitForCommand) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         ZDO_MGMT_PERMIT_JOIN_RSP result = null;
@@ -791,7 +791,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
         if (response == null || response.Status != 0) {
             logger.trace("ZDO_MGMT_PERMIT_JOIN_REQ failed, received {}", response);
             waiter.cleanup();
-        } else if (waitForCommand == true) {
+        } else if (!waitForCommand) {
             result = (ZDO_MGMT_PERMIT_JOIN_RSP) waiter.getCommand(TIMEOUT);
         }
         unLock3WayConversation(request);
@@ -867,7 +867,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
             Class<?> clz = request.getClass();
             Thread requestor = null;
             while ((requestor = conversation3Way.get(clz)) != null) {
-                if (requestor.isAlive() == false) {
+                if (!requestor.isAlive()) {
                     logger.error("Thread {} whom requested {} DIED before unlocking the conversation");
                     logger.debug("The thread {} who was waiting for {} to complete DIED, so we have to remove the lock");
                     conversation3Way.put(clz, null);
@@ -912,7 +912,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public ZDO_SIMPLE_DESC_RSP sendZDOSimpleDescriptionRequest(ZDO_SIMPLE_DESC_REQ request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         ZDO_SIMPLE_DESC_RSP result = null;
@@ -1284,7 +1284,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public AF_REGISTER_SRSP sendAFRegister(AF_REGISTER request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
 
@@ -1293,7 +1293,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public AF_DATA_CONFIRM sendAFDataRequest(AF_DATA_REQUEST request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         AF_DATA_CONFIRM result = null;
@@ -1313,7 +1313,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public ZDO_BIND_RSP sendZDOBind(ZDO_BIND_REQ request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         ZDO_BIND_RSP result = null;
@@ -1332,7 +1332,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
     }
 
     public ZDO_UNBIND_RSP sendZDOUnbind(ZDO_UNBIND_REQ request) {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
         	return null;
         }
         ZDO_UNBIND_RSP result = null;
@@ -1430,7 +1430,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
      * @since 0.2.0
      */
     public long getExtendedPanId() {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
             logger.info("Failed to reach the {} level: getExtendedPanId() failed", DriverStatus.NETWORK_READY);
             return -1;
         }
@@ -1457,7 +1457,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
             return ieeeAddress;
         }
 
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
             logger.info("Failed to reach the {} level: getIeeeAddress() failed", DriverStatus.NETWORK_READY);
             return -1;
         }
@@ -1500,7 +1500,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
      * @since 0.2.0
      */
     public int getCurrentChannel() {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
             logger.info("Failed to reach the {} level: getCurrentChannel() failed", DriverStatus.NETWORK_READY);
             return -1;
         }
@@ -1519,7 +1519,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
      * @since 0.2.0
      */
     public int getCurrentState() {
-        if (waitForNetwork() == false) {
+        if (!waitForNetwork()) {
             logger.info("Failed to reach the {} level: getCurrentChannel() failed", DriverStatus.NETWORK_READY);
             return -1;
         }

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/ByteUtils.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/ByteUtils.java
@@ -150,7 +150,7 @@ public class ByteUtils {
     public static int[] fromBase16toIntArray(String bytes) {
         final String PATTERN = "\\s*((0x[0-9a-f]{2}|[0-9a-f]{2})\\s*)+";
         bytes = bytes.toLowerCase();
-        if (bytes.matches(PATTERN) == false) {
+        if (!bytes.matches(PATTERN)) {
             throw new IllegalArgumentException("Unable to parse " + bytes + " doesn't match regex " + PATTERN);
         }
         String[] singleBytes = bytes.split("\\s+");

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/CircularBufferInt.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/CircularBufferInt.java
@@ -47,12 +47,12 @@ public class CircularBufferInt {
     public CircularBufferInt(final int[] data, final int size, final boolean cyclic) {
         buffer = new int[size];
         overwrite = cyclic;
-        if (cyclic == false && data.length > size) {
+        if (!cyclic && data.length > size) {
             throw new IndexOutOfBoundsException(
                     "Trying to copy " + data.length + " to non-cyclic buffer of " + size + "." +
                             "You should either increase the size of the buffer or set it as cyclic"
             );
-        } else if (cyclic == true && data.length > size) {
+        } else if (cyclic && data.length > size) {
             for (tail = 0; tail < buffer.length; tail++) {
                 buffer[tail] = data[data.length - buffer.length + tail];
             }

--- a/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -1333,7 +1333,7 @@ public final class ZigBeeConsole {
                 return false;
             }
             
-            if(attribute.isWritable() == false) {
+            if(!attribute.isWritable()) {
                 print(attribute.getName() + " is not writable");
             	return true;
             }
@@ -1686,7 +1686,7 @@ public final class ZigBeeConsole {
                 return false;
             }
 
-            if(attribute.isWritable() == false) {
+            if(!attribute.isWritable()) {
                 print(attribute.getName() + " is not writable");
                 return true;
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed