### PR TITLE
Code quality fix - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/MarkableInputStream.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/MarkableInputStream.java
@@ -70,7 +70,7 @@ public class MarkableInputStream
              */
             buffer = new CircularBufferInt(size, true);
             idx = buffer.size();
-        } else if (buffer != null && size > buffer.slots()) {
+        } else if (size > buffer.slots()) {
             /*
              * The mark was set so we have should copy unread data to the new buffer
              */
@@ -100,13 +100,13 @@ public class MarkableInputStream
              * No mark set so reading from the stream
              */
             return in.read();
-        } else if (buffer != null && idx < buffer.size()) {
+        } else if (idx < buffer.size()) {
             /*
              * Mark was set and also buffer was reset, and it has not been empty yet
              */
             idx += 1;
             return buffer.remove();
-        } else if (buffer != null && idx >= buffer.size()) {
+        } else if (idx >= buffer.size()) {
             /*
              * Mark was set, but buffer has been exhausted
              */

--- a/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
+++ b/zigbee-console-common/src/main/java/org/bubblecloud/zigbee/ZigBeeConsole.java
@@ -1148,13 +1148,14 @@ public final class ZigBeeConsole {
             }
 
             final Reporter reporter = device.getCluster(clusterId).getAttribute(attributeId).getReporter();
-            reporter.setMinimumReportingInterval(minInterval);
-            reporter.setMaximumReportingInterval(maxInterval);
-
+            
             if (reporter == null) {
                 print("Attribute does not provide reports.");
                 return true;
             }
+
+            reporter.setMinimumReportingInterval(minInterval);
+            reporter.setMaximumReportingInterval(maxInterval);
 
             reporter.addReportListener(consoleReportListener, true);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2583

Please let me know if you have any questions.

Faisal Hameed