### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/ZigBeeApiConstants.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/ZigBeeApiConstants.java
@@ -63,6 +63,8 @@ import org.bubblecloud.zigbee.api.cluster.impl.api.security_safety.IASZone;
  * @since 0.4.0
  */
 public class ZigBeeApiConstants {
+    
+    private ZigBeeApiConstants() {}
 
 	/**
 	 * Home Automation Profile definition

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/attribute/Attributes.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/attribute/Attributes.java
@@ -32,6 +32,8 @@ import org.bubblecloud.zigbee.api.cluster.impl.api.core.ZigBeeType;
  * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)
  */
 public class Attributes {
+    
+    private Attributes() {}
 
     final static public   AttributeDescriptor LOCK_STATE = new AbstractAttribute()
 		    .setId(0x0)

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/ZCLLayer.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/ZCLLayer.java
@@ -28,6 +28,8 @@ package org.bubblecloud.zigbee.api.cluster.impl.core;
  * @version $LastChangedRevision: 799 $ ($LastChangedDate: 2013-08-06 19:00:05 +0300 (Tue, 06 Aug 2013) $)
  */
 public class ZCLLayer {
+    
+    private ZCLLayer() {}
 
     static int transactionId;
 

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/model/IEEEAddress.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/model/IEEEAddress.java
@@ -31,6 +31,8 @@ import java.util.StringTokenizer;
  * @since 0.1.0
  */
 public class IEEEAddress {
+    
+    private IEEEAddress() {}
 
     public static final long fromColonNotation(String ieee) {
         StringTokenizer scanner = new StringTokenizer(ieee, ":");

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/model/NetworkAddress.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/model/NetworkAddress.java
@@ -29,6 +29,8 @@ package org.bubblecloud.zigbee.network.model;
  * @since 0.1.0
  */
 public class NetworkAddress {
+    
+    private NetworkAddress() {}
 
     public static final short fromDecimal(int value) {
         return (short) value;

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolCMD.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/packet/ZToolCMD.java
@@ -29,6 +29,9 @@ package org.bubblecloud.zigbee.network.packet;
  *          +0300 (Tue, 06 Aug 2013) $)
  */
 public class ZToolCMD {
+    
+    private ZToolCMD() {}
+    
 	/**
 	 * AF Data confirm.
 	 */

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/zcl/ZclUtil.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/zcl/ZclUtil.java
@@ -30,6 +30,8 @@ public class ZclUtil {
      * The logger.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(ZigBeeEndpointImpl.class);
+    
+    private ZclUtil() {}
 
     /**
      * Formats integer value to hex string.

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/ArraysUtil.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/ArraysUtil.java
@@ -29,6 +29,8 @@ package org.bubblecloud.zigbee.util;
  * @since 0.4.0
  */
 public class ArraysUtil {
+    
+    private ArraysUtil() {}
 
     /**
      * Create a new <code>int[]</code> by concatenating prefix and postfix

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/ByteUtils.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/ByteUtils.java
@@ -37,6 +37,8 @@ public class ByteUtils {
 
     private final static Logger logger = LoggerFactory.getLogger(ByteUtils.class);
 
+    private ByteUtils() {}
+    
     /**
      * There is a slight problem with this method that you might have noticed;  a Java int is signed, so we can't make
      * use of the 32nd bit.  This means we this method does not support a four byte value with msb greater than 01111111 ((2^7-1) or 127).

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/Integers.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/Integers.java
@@ -34,6 +34,8 @@ package org.bubblecloud.zigbee.util;
  */
 public class Integers {
 
+    private Integers() {}
+    
     /**
      * @param x the long containing the data
      * @param n the index of the byte to return

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/NetworkAddressUtil.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/NetworkAddressUtil.java
@@ -7,6 +7,8 @@ import org.bubblecloud.zigbee.network.packet.ZToolAddress16;
  * @author Tommi S.E. Laukkanen
  */
 public class NetworkAddressUtil {
+    
+    private NetworkAddressUtil() {}
 
     /**
      * Converts short network address to integer format.

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/ThreadUtils.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/util/ThreadUtils.java
@@ -34,6 +34,8 @@ public class ThreadUtils {
 
     private final static Logger logger = LoggerFactory.getLogger(ThreadUtils.class);
 
+    private ThreadUtils() {}
+    
     /**
      * Wait for x ms even if interrupt are sent to the thread waiting
      *

--- a/zigbee-serial-android/src/main/java/org/bubblecloud/zigbee/util/FIFOBuffers.java
+++ b/zigbee-serial-android/src/main/java/org/bubblecloud/zigbee/util/FIFOBuffers.java
@@ -5,6 +5,9 @@ package org.bubblecloud.zigbee.util;
  */
 public class FIFOBuffers
 {
+    
+    private FIFOBuffers() {}
+    
     public static int popInto(FIFOByteBuffer source, byte[] destination)
     {
         int i=0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed