### PR TITLE
Code quality fix - Method invokes inefficient Number constructor; use static valueOf instead.

### DIFF
--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/AnalogReporterImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/AnalogReporterImpl.java
@@ -104,9 +104,9 @@ public class AnalogReporterImpl extends ReporterBase implements AnalogReporter {
     private void setReportableChangeValue(Number n) {
         final ZigBeeType type = attribute.getZigBeeType();
         if (type.getJavaClass() == Long.class) {
-            minimumChange = new Long(n.longValue());
+            minimumChange = Long.valueOf(n.longValue());
         } else if (type.getJavaClass() == Integer.class) {
-            minimumChange = new Integer(n.intValue());
+            minimumChange = Integer.valueOf(n.intValue());
         } else if (type.getJavaClass() == Float.class) {
             minimumChange = new Float(n.floatValue());
         } else if (type.getJavaClass() == Double.class) {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/DefaultDeserializer.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/core/DefaultDeserializer.java
@@ -163,9 +163,9 @@ public class DefaultDeserializer implements ZBDeserializer {
             case SignedInteger8bit:
                 byte b = read_byte();
                 if (type == ZigBeeType.UnsignedInteger8bit) {
-                    value[0] = new Integer(b & 0xFF);
+                    value[0] = Integer.valueOf(b & 0xFF);
                 } else {
-                    value[0] = new Integer(b);
+                    value[0] = Integer.valueOf(b);
                 }
                 break;
             case Data16bit:
@@ -186,9 +186,9 @@ public class DefaultDeserializer implements ZBDeserializer {
             case SignedInteger24bit:
                 int i = read_int24bit();
                 if (type == ZigBeeType.UnsignedInteger32bit) {
-                    value[0] = new Long(i & 0xFFFFFFFF);
+                    value[0] = Long.valueOf(i & 0xFFFFFFFF);
                 } else {
-                    value[0] = new Integer(i);
+                    value[0] = Integer.valueOf(i);
                 }
                 break;
             case Data32bit:

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/security_safety/ias_ace/ZoneIDMapResponseImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/api/cluster/impl/security_safety/ias_ace/ZoneIDMapResponseImpl.java
@@ -43,7 +43,7 @@ public class ZoneIDMapResponseImpl extends ResponseImpl implements ZoneIDMapResp
 
         zonesID = new ZoneTableImpl();
         for (int i = 0; i < 16; i++)
-            zonesID.addZone(new Short(deserializer.read_short()), null, null);
+            zonesID.addZone(Short.valueOf(deserializer.read_short()), null, null);
     }
 
     public Zone[] getZonesID() {

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeEndpointImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/impl/ZigBeeEndpointImpl.java
@@ -404,7 +404,7 @@ public class ZigBeeEndpointImpl implements ZigBeeEndpoint, ApplicationFrameworkM
     @Override
     public boolean bindTo(ZigBeeEndpoint endpoint, int clusterId) throws ZigBeeNetworkManagerException {
         logger.info("Binding from endpoint {} to {} for cluster {}", new Object[]{
-                getEndpointId(), endpoint.getEndpointId(), new Integer(clusterId)
+                getEndpointId(), endpoint.getEndpointId(), Integer.valueOf(clusterId)
         });
 
         final ZDO_BIND_RSP response = networkManager.sendZDOBind(new ZDO_BIND_REQ(
@@ -428,7 +428,7 @@ public class ZigBeeEndpointImpl implements ZigBeeEndpoint, ApplicationFrameworkM
     @Override
     public boolean unbindFrom(ZigBeeEndpoint endpoint, int clusterId) throws ZigBeeNetworkManagerException {
         logger.info("Un-binding from endpoint {} to {} for cluster {}", new Object[]{
-                getEndpointId(), endpoint.getEndpointId(), new Integer(clusterId)
+                getEndpointId(), endpoint.getEndpointId(), Integer.valueOf(clusterId)
         });
 
         final ZDO_UNBIND_RSP response = networkManager.sendZDOUnbind(new ZDO_UNBIND_REQ(
@@ -458,7 +458,7 @@ public class ZigBeeEndpointImpl implements ZigBeeEndpoint, ApplicationFrameworkM
         short dstEP = ApplicationFrameworkLayer.getAFLayer(networkManager).getSendingEndpoint(this.getProfileId(), clusterId);
 
         logger.info("Binding from endpoint {} to {} for cluster {}", new Object[]{
-                getEndpointId(), IEEEAddress.toString(networkManager.getIeeeAddress()) + "/" + dstEP, new Integer(clusterId)
+                getEndpointId(), IEEEAddress.toString(networkManager.getIeeeAddress()) + "/" + dstEP, Integer.valueOf(clusterId)
         });
 
         final ZDO_BIND_RSP response = networkManager.sendZDOBind(new ZDO_BIND_REQ(

--- a/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
+++ b/zigbee-api/src/main/java/org/bubblecloud/zigbee/network/port/ZigBeeNetworkManagerImpl.java
@@ -1703,7 +1703,7 @@ public class ZigBeeNetworkManagerImpl implements ZigBeeNetworkManager {
                         output[j] = this.out[i][j];
                 }
 
-                if (newDevice(new AF_REGISTER(new Byte(this.ep[i] + ""), this.prof[i], new Short(this.dev[i] + ""), new Byte(this.ver[i] + ""), input, output))) {
+                if (newDevice(new AF_REGISTER(Byte.valueOf(this.ep[i] + ""), this.prof[i], Short.valueOf(this.dev[i] + ""), Byte.valueOf(this.ver[i] + ""), input, output))) {
                     logger.debug("Custom device {} registered at endpoint {}", this.dev[i], this.ep[i]);
                 }
                 else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
findbugs:DM_NUMBER_CTOR - Performance - Method invokes inefficient Number constructor; use static valueOf instead.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/findbugs:DM_NUMBER_CTOR

Please let me know if you have any questions.

Faisal Hameed