### PR TITLE
Fix POM and remove test from old API

### DIFF
--- a/zigbee-gateway-server/pom.xml
+++ b/zigbee-gateway-server/pom.xml
@@ -28,9 +28,8 @@
 
         <dependency>
             <groupId>org.bubblecloud.zigbee4java</groupId>
-            <artifactId>zigbee-api</artifactId>
+            <artifactId>zigbee-common</artifactId>
             <version>3.0.3-SNAPSHOT</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/zigbee-gateway-server/src/test/java/org/bubblecloud/zigbee/ZigBeeNetworkTest.java
+++ b/zigbee-gateway-server/src/test/java/org/bubblecloud/zigbee/ZigBeeNetworkTest.java
@@ -75,45 +75,4 @@ public abstract class ZigBeeNetworkTest {
         zigbeeNetworkManager.shutdown();
     }
 
-    @Test
-    @Ignore
-    public void testZigBeeApi() throws Exception {
-        
-        final Set<DiscoveryMode> discoveryModes = DiscoveryMode.ALL;
-        discoveryModes.remove(DiscoveryMode.LinkQuality);
-        final ZigBeeApi zigbeeApi = new ZigBeeApi(port, 4951, 11, null, false, discoveryModes);
-        zigbeeApi.startup();
-
-        Thread.sleep(1000);
-
-        logger.info("Listing devices:");
-        for (final Device device : zigbeeApi.getZigBeeApiContext().getDevices()) {
-            logger.info(device.getClass().getSimpleName() + " : " + device.getEndpoint().getEndpointId());
-        }
-
-        while (true) {
-            try {
-                final Device switchDevice = zigbeeApi.getZigBeeApiContext().getDevice("00:12:4B:00:01:DD:8B:21/2");
-                final Device lampDevice = zigbeeApi.getZigBeeApiContext().getDevice("00:17:88:01:00:BE:51:EC/11");
-
-                if (lampDevice == null) {
-                    continue;
-                }
-
-                Thread.sleep(1000);
-
-                final OnOff onOff = lampDevice.getCluster(OnOff.class);
-                onOff.off();
-
-                break;
-            } catch (final Throwable t) {
-                logger.error("Error getting information for device.", t);
-                break;
-            }
-        }
-
-        zigbeeApi.shutdown();
-    }
-
-
 }


### PR DESCRIPTION
I just grabbed a clean fork of the repo to tidy things up a bit, and it looks like the pom is broken and some tests refer to the old API. This just tidies this up - maybe it was like that for a reason, but when starting from a fresh fork, it doesn't work currently.
Signed-off-by: Chris Jackson chris@cd-jackson.com
