### PR TITLE
Destination device address

### DIFF
--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZclCustomResponseMatcher.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZclCustomResponseMatcher.java
@@ -7,25 +7,26 @@ import org.bubblecloud.zigbee.v3.zcl.protocol.command.general.DefaultResponseCom
  * ZCL custom response matcher.
  */
 public class ZclCustomResponseMatcher implements CommandResponseMatcher {
-        @Override
-        public boolean isMatch(Command request, Command response) {
-            if (((ZclCommand) request).getTransactionId() != null) {
-                final byte transactionId = ((ZclCommand) request).getTransactionId();
-                if (new Byte(transactionId).equals(((ZclCommand) response).getTransactionId())) {
-                    if (response instanceof DefaultResponseCommand) {
-                        if (((DefaultResponseCommand) response).getStatusCode() == 0) {
-                            return false; // Default response success another response incoming, skip this one.
-                        } else {
-                            return true; // Default response failure, return this one.
-                        }
+    @Override
+    public boolean isMatch(Command request, Command response) {
+        if (((ZclCommand) request).getTransactionId() != null) {
+            final byte transactionId = ((ZclCommand) request).getTransactionId();
+            if (new Byte(transactionId).equals(((ZclCommand) response).getTransactionId())) {
+                if (response instanceof DefaultResponseCommand) {
+                    if (((DefaultResponseCommand) response).getStatusCode() == 0) {
+                        return false; // Default response success another
+                                      // response incoming, skip this one.
                     } else {
-                        return true; // This is the actual response, return this one.
+                        return true; // Default response failure, return this one.
                     }
                 } else {
-                    return false; // Transaction ID mismatch.
+                    return true; // This is the actual response, return this one.
                 }
             } else {
-                return false; // Transaction ID not set in original command.
+                return false; // Transaction ID mismatch.
             }
+        } else {
+            return false; // Transaction ID not set in original command.
         }
     }
+}

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeAddress.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeAddress.java
@@ -1,23 +1,21 @@
 package org.bubblecloud.zigbee.v3;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
-
 /**
  * ZigBee destination can be either group or device.
  */
-public class ZigBeeDestination {
+public abstract class ZigBeeAddress {
     /**
      * Check whether this destination is ZigBee group.
      * @return TRUE if this is ZigBee group.
      */
-    public boolean isGroup() {
-        return this instanceof ZigBeeGroup;
-    }
+    public abstract boolean isGroup();
+  //      return this instanceof ZigBeeGroupDestination;
+//    }
 
     /**
      * Dummy setter for JSON RPC deserialization.
      * @param value the dummy value
      */
-    public void setGroup(final boolean value) {
-    }
+//    public void setGroup(final boolean value) {
+  //  }
 }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeAddress.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeAddress.java
@@ -1,7 +1,7 @@
 package org.bubblecloud.zigbee.v3;
 
 /**
- * ZigBee destination can be either group or device.
+ * Defines an abstract ZigBee address
  */
 public abstract class ZigBeeAddress {
     /**
@@ -9,13 +9,4 @@ public abstract class ZigBeeAddress {
      * @return TRUE if this is ZigBee group.
      */
     public abstract boolean isGroup();
-  //      return this instanceof ZigBeeGroupDestination;
-//    }
-
-    /**
-     * Dummy setter for JSON RPC deserialization.
-     * @param value the dummy value
-     */
-//    public void setGroup(final boolean value) {
-  //  }
 }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeApi.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeApi.java
@@ -180,7 +180,7 @@ public class ZigBeeApi {
 
     /**
      * Labels destination.
-     * @param destination the destination
+     * @param destination the {@link ZigBeeAddress}
      */
     public void label(final ZigBeeAddress destination, final String label) {
         if (destination.isGroup()) {
@@ -262,7 +262,7 @@ public class ZigBeeApi {
 
     /**
      * Switches destination on.
-     * @param destination the destination
+     * @param destination the {@link ZigBeeAddress}
      * @return the command result future.
      */
     public Future<CommandResult> on(final ZigBeeAddress destination) {
@@ -273,7 +273,7 @@ public class ZigBeeApi {
 
     /**
      * Switches destination off.
-     * @param destination the destination
+     * @param destination the {@link ZigBeeAddress}
      * @return the command result future.
      */
     public Future<CommandResult> off(final ZigBeeAddress destination) {
@@ -283,7 +283,7 @@ public class ZigBeeApi {
 
     /**
      * Colors device light.
-     * @param destination the destination
+     * @param destination the {@link ZigBeeAddress}
      * @param red the red component [0..1]
      * @param green the green component [0..1]
      * @param blue the blue component [0..1]
@@ -314,7 +314,7 @@ public class ZigBeeApi {
 
     /**
      * Moves device level.
-     * @param destination the destination
+     * @param destination the {@link ZigBeeAddress}
      * @param level the level
      * @param time the transition time
      * @return the command result future.
@@ -339,7 +339,7 @@ public class ZigBeeApi {
 
     /**
      * Locks door.
-     * @param destination the destination
+     * @param destination the {@link ZigBeeAddress}
      * @param pinCode the pin code
      * @return the command result future.
      */
@@ -353,7 +353,7 @@ public class ZigBeeApi {
 
     /**
      * Unlocks door.
-     * @param destination the destination
+     * @param destination the {@link ZigBeeAddress}
      * @param pinCode the pin code
      * @return the command result future.
      */
@@ -367,7 +367,7 @@ public class ZigBeeApi {
 
     /**
      * This command uses the WD capabilities to emit a quick audible/visible pulse called a "squawk".
-     * @param destination the destination
+     * @param destination the {@link ZigBeeAddress}
      * @param mode the mode
      * @param strobe the strobe
      * @param level the level
@@ -385,7 +385,7 @@ public class ZigBeeApi {
 
     /**
      * Starts warning.
-     * @param destination the destination
+     * @param destination the {@link ZigBeeAddress}
      * @param mode the mode
      * @param strobe the strobe
      * @param duration the duration
@@ -445,8 +445,6 @@ public class ZigBeeApi {
         command.setIdentifiers(Collections.singletonList(attributeIdentifier));
 
         command.setDestinationAddress(device.getDeviceAddress());
-//        command.setDestinationAddress(device.getNetworkAddress());
-  //      command.setDestinationEndpoint(device.getEndpoint());
 
         return unicast(command, new ZclCustomResponseMatcher());
     }
@@ -478,8 +476,6 @@ public class ZigBeeApi {
         command.setRecords(Collections.singletonList(record));
 
         command.setDestinationAddress(device.getDeviceAddress());
-//        command.setDestinationAddress(device.getNetworkAddress());
-  //      command.setDestinationEndpoint(device.getEndpoint());
 
         return unicast(command, new ZclCustomResponseMatcher());
     }
@@ -522,8 +518,6 @@ public class ZigBeeApi {
         command.setGroupName(groupName);
 
         command.setDestinationAddress(device.getDeviceAddress());
-//        command.setDestinationAddress(device.getNetworkAddress());
-  //      command.setDestinationEndpoint(device.getEndpoint());
 
         return unicast(command, new ZclCustomResponseMatcher());
     }
@@ -539,8 +533,6 @@ public class ZigBeeApi {
         command.setGroupCount(0);
         command.setGroupList(Collections.<Unsigned16BitInteger>emptyList());
         command.setDestinationAddress(device.getDeviceAddress());
-//        command.setDestinationAddress(device.getNetworkAddress());
-  //      command.setDestinationEndpoint(device.getEndpoint());
 
         return unicast(command, new ZclCustomResponseMatcher());
     }
@@ -556,8 +548,6 @@ public class ZigBeeApi {
         command.setGroupId(groupId);
 
         command.setDestinationAddress(device.getDeviceAddress());
-//        command.setDestinationAddress(device.getNetworkAddress());
-  //      command.setDestinationEndpoint(device.getEndpoint());
 
         return unicast(command, new ZclCustomResponseMatcher());
     }
@@ -573,14 +563,12 @@ public class ZigBeeApi {
         command.setGroupId(groupId);
 
         command.setDestinationAddress(device.getDeviceAddress());
-//        command.setDestinationAddress(device.getNetworkAddress());
-  //      command.setDestinationEndpoint(device.getEndpoint());
 
         return unicast(command, new ZclCustomResponseMatcher());
     }
 
     /**
-     * Sends command to destination.
+     * Sends command to {@link ZigBeeAddress}.
      * @param destination the destination
      * @param command the command
      * @return the command result future
@@ -588,11 +576,8 @@ public class ZigBeeApi {
     private Future<CommandResult> send(ZigBeeAddress destination, ZclCommand command) {
         command.setDestinationAddress(destination);
         if (destination.isGroup()) {
-//            command.setDestinationGroupId(((ZigBeeGroupDestination) destination).getGroupId());
             return broadcast(command);
         } else {
-//            command.setDestinationAddress(((ZigBeeDevice) destination).getNetworkAddress());
-  //          command.setDestinationEndpoint(((ZigBeeDevice) destination).getEndpoint());
             return unicast(command);
         }
     }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeDevice.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeDevice.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 /**
  * Value object for ZigBee device.
  */
-public class ZigBeeDevice extends ZigBeeDestination {
+public class ZigBeeDevice {
     /**
      * The IEEE address.
      */
@@ -13,11 +13,12 @@ public class ZigBeeDevice extends ZigBeeDestination {
     /**
      * The network address.
      */
-    private int networkAddress;
+    ZigBeeDeviceAddress networkDestination = new ZigBeeDeviceAddress();
+//    private int networkAddress;
     /**
      * The end point.
      */
-    private int endpoint;
+//    private int endpoint;
     /**
      * The profile ID.
      */
@@ -87,7 +88,7 @@ public class ZigBeeDevice extends ZigBeeDestination {
      * @return the end point
      */
     public int getEndpoint() {
-        return endpoint;
+        return networkDestination.getEndpoint();
     }
 
     /**
@@ -95,7 +96,7 @@ public class ZigBeeDevice extends ZigBeeDestination {
      * @param endpoint the end point
      */
     public void setEndpoint(int endpoint) {
-        this.endpoint = endpoint;
+    	networkDestination.setEndpoint(endpoint);
     }
 
     /**
@@ -135,7 +136,11 @@ public class ZigBeeDevice extends ZigBeeDestination {
      * @return the network address
      */
     public int getNetworkAddress() {
-        return networkAddress;
+        return networkDestination.getAddress();
+    }
+    
+    public ZigBeeDeviceAddress getDeviceAddress() {
+        return networkDestination;
     }
 
     /**
@@ -143,7 +148,7 @@ public class ZigBeeDevice extends ZigBeeDestination {
      * @param networkAddress the network address
      */
     public void setNetworkAddress(int networkAddress) {
-        this.networkAddress = networkAddress;
+    	networkDestination.setAddress(networkAddress);
     }
 
     /**
@@ -230,8 +235,7 @@ public class ZigBeeDevice extends ZigBeeDestination {
     public String toString() {
         return "ZigBeeDevice " +
                 "label=" + label +
-                ", networkAddress=" + networkAddress +
-                ", endpoint=" + endpoint +
+                ", networkAddress=" + networkDestination.toString() +
                 ", ieeeAddress=" + ieeeAddress +
                 ", profileId=" + profileId +
                 ", deviceType=" + deviceType +

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeDevice.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeDevice.java
@@ -13,12 +13,7 @@ public class ZigBeeDevice {
     /**
      * The network address.
      */
-    ZigBeeDeviceAddress networkDestination = new ZigBeeDeviceAddress();
-//    private int networkAddress;
-    /**
-     * The end point.
-     */
-//    private int endpoint;
+    private final ZigBeeDeviceAddress networkAddress = new ZigBeeDeviceAddress();
     /**
      * The profile ID.
      */
@@ -51,8 +46,10 @@ public class ZigBeeDevice {
      * Label.
      */
     private String label;
+
     /**
      * Gets the device ID.
+     * 
      * @return the device ID
      */
     public int getDeviceId() {
@@ -61,7 +58,9 @@ public class ZigBeeDevice {
 
     /**
      * Sets the device ID.
-     * @param deviceId the device ID.
+     * 
+     * @param deviceId
+     *            the device ID.
      */
     public void setDeviceId(int deviceId) {
         this.deviceId = deviceId;
@@ -69,6 +68,7 @@ public class ZigBeeDevice {
 
     /**
      * Gets device version.
+     * 
      * @return the device version
      */
     public int getDeviceVersion() {
@@ -77,7 +77,9 @@ public class ZigBeeDevice {
 
     /**
      * Sets device version.
-     * @param deviceVersion the device version
+     * 
+     * @param deviceVersion
+     *            the device version
      */
     public void setDeviceVersion(int deviceVersion) {
         this.deviceVersion = deviceVersion;
@@ -85,22 +87,26 @@ public class ZigBeeDevice {
 
     /**
      * Gets end point.
+     * 
      * @return the end point
      */
     public int getEndpoint() {
-        return networkDestination.getEndpoint();
+        return networkAddress.getEndpoint();
     }
 
     /**
      * Sets end point
-     * @param endpoint the end point
+     * 
+     * @param endpoint
+     *            the end point
      */
     public void setEndpoint(int endpoint) {
-    	networkDestination.setEndpoint(endpoint);
+        networkAddress.setEndpoint(endpoint);
     }
 
     /**
      * Gets IEEE Address.
+     * 
      * @return the IEEE address
      */
     public long getIeeeAddress() {
@@ -109,7 +115,9 @@ public class ZigBeeDevice {
 
     /**
      * Sets IEEE Address.
-     * @param ieeeAddress the IEEE address
+     * 
+     * @param ieeeAddress
+     *            the IEEE address
      */
     public void setIeeeAddress(long ieeeAddress) {
         this.ieeeAddress = ieeeAddress;
@@ -117,6 +125,7 @@ public class ZigBeeDevice {
 
     /**
      * Gets input cluster IDs.
+     * 
      * @return the input cluster IDs
      */
     public int[] getInputClusterIds() {
@@ -125,7 +134,9 @@ public class ZigBeeDevice {
 
     /**
      * Sets input cluster IDs.
-     * @param inputClusterIds the input cluster IDs
+     * 
+     * @param inputClusterIds
+     *            the input cluster IDs
      */
     public void setInputClusterIds(int[] inputClusterIds) {
         this.inputClusterIds = inputClusterIds;
@@ -133,26 +144,35 @@ public class ZigBeeDevice {
 
     /**
      * Gets network address.
+     * 
      * @return the network address
      */
     public int getNetworkAddress() {
-        return networkDestination.getAddress();
+        return networkAddress.getAddress();
     }
-    
+
+    /**
+     * Gets the device address
+     * 
+     * @return the {@link ZigBeeDeviceAddress}
+     */
     public ZigBeeDeviceAddress getDeviceAddress() {
-        return networkDestination;
+        return networkAddress;
     }
 
     /**
      * Sets network address.
-     * @param networkAddress the network address
+     * 
+     * @param networkAddress
+     *            the network address
      */
     public void setNetworkAddress(int networkAddress) {
-    	networkDestination.setAddress(networkAddress);
+        this.networkAddress.setAddress(networkAddress);
     }
 
     /**
      * Gets output cluster IDs.
+     * 
      * @return the output cluster IDs
      */
     public int[] getOutputClusterIds() {
@@ -161,14 +181,17 @@ public class ZigBeeDevice {
 
     /**
      * Sets output cluster IDs.
-     * @param outputClusterIds the output cluster IDs
+     * 
+     * @param outputClusterIds
+     *            the output cluster IDs
      */
-   public void setOutputClusterIds(int[] outputClusterIds) {
+    public void setOutputClusterIds(int[] outputClusterIds) {
         this.outputClusterIds = outputClusterIds;
     }
 
     /**
      * Gets profile ID.
+     * 
      * @return the profile ID.
      */
     public int getProfileId() {
@@ -177,7 +200,9 @@ public class ZigBeeDevice {
 
     /**
      * Sets profile ID
-     * @param profileId the profile ID
+     * 
+     * @param profileId
+     *            the profile ID
      */
     public void setProfileId(int profileId) {
         this.profileId = profileId;
@@ -185,6 +210,7 @@ public class ZigBeeDevice {
 
     /**
      * Gets device logical type.
+     * 
      * @return the device logical type.
      */
     public int getDeviceType() {
@@ -193,7 +219,9 @@ public class ZigBeeDevice {
 
     /**
      * Sets device logical type.
-     * @param deviceType the device logical type
+     * 
+     * @param deviceType
+     *            the device logical type
      */
     public void setDeviceType(int deviceType) {
         this.deviceType = deviceType;
@@ -201,6 +229,7 @@ public class ZigBeeDevice {
 
     /**
      * Gets manufacturer code.
+     * 
      * @return the manufacturer code.
      */
     public int getManufacturerCode() {
@@ -209,7 +238,9 @@ public class ZigBeeDevice {
 
     /**
      * Sets manufacturer code.
-     * @param manufacturerCode the manufacturer code.
+     * 
+     * @param manufacturerCode
+     *            the manufacturer code.
      */
     public void setManufacturerCode(int manufacturerCode) {
         this.manufacturerCode = manufacturerCode;
@@ -217,6 +248,7 @@ public class ZigBeeDevice {
 
     /**
      * Gets label.
+     * 
      * @return the label
      */
     public String getLabel() {
@@ -225,7 +257,9 @@ public class ZigBeeDevice {
 
     /**
      * Sets label.
-     * @param label the label
+     * 
+     * @param label
+     *            the label
      */
     public void setLabel(String label) {
         this.label = label;
@@ -233,16 +267,12 @@ public class ZigBeeDevice {
 
     @Override
     public String toString() {
-        return "ZigBeeDevice " +
-                "label=" + label +
-                ", networkAddress=" + networkDestination.toString() +
-                ", ieeeAddress=" + ieeeAddress +
-                ", profileId=" + profileId +
-                ", deviceType=" + deviceType +
-                ", deviceId=" + deviceId +
-                ", manufacturerCode=" + manufacturerCode +
-                ", deviceVersion=" + deviceVersion +
-                ", inputClusterIds=" + Arrays.toString(inputClusterIds) +
-                ", outputClusterIds=" + Arrays.toString(outputClusterIds);
+        return "ZigBeeDevice " + "label=" + label + ", networkAddress="
+                + networkAddress.toString() + ", ieeeAddress=" + ieeeAddress
+                + ", profileId=" + profileId + ", deviceType=" + deviceType
+                + ", deviceId=" + deviceId + ", manufacturerCode="
+                + manufacturerCode + ", deviceVersion=" + deviceVersion
+                + ", inputClusterIds=" + Arrays.toString(inputClusterIds)
+                + ", outputClusterIds=" + Arrays.toString(outputClusterIds);
     }
 }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeDeviceAddress.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeDeviceAddress.java
@@ -1,47 +1,78 @@
 package org.bubblecloud.zigbee.v3;
 
 /**
+ * Defines a unicast ZigBee address
  * 
  * @author Chris Jackson
- *
  */
 public class ZigBeeDeviceAddress extends ZigBeeAddress {
-	private int networkAddress;
-	private int endpoint;
-	
-	public ZigBeeDeviceAddress(int networkAddress, int endpoint) {
-		this.networkAddress = networkAddress;
-		this.endpoint = endpoint;
-	}
+    private int networkAddress;
+    private int endpoint;
 
-	public ZigBeeDeviceAddress() {
-		// TODO Auto-generated constructor stub
-	}
+    /**
+     * Constructor
+     * 
+     * @param networkAddress
+     *            the network address
+     * @param endpoint
+     *            the endpoint number
+     */
+    public ZigBeeDeviceAddress(int networkAddress, int endpoint) {
+        this.networkAddress = networkAddress;
+        this.endpoint = endpoint;
+    }
 
-	@Override
-	public boolean isGroup() {
-		return false;
-	}
+    /**
+     * Default constructor
+     */
+    public ZigBeeDeviceAddress() {
+    }
 
-	public void setEndpoint(int endpoint) {
-		this.endpoint = endpoint;
-	}
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
 
-	public int getEndpoint() {
-		return endpoint;
-	}
+    /**
+     * Sets the endpoint number
+     * 
+     * @param endpoint
+     *            number
+     */
+    public void setEndpoint(int endpoint) {
+        this.endpoint = endpoint;
+    }
 
-	public int getAddress() {
-		return networkAddress;
-	}
+    /**
+     * Returns the endpoint number
+     * 
+     * @return the endpoint number
+     */
+    public int getEndpoint() {
+        return endpoint;
+    }
 
-	public void setAddress(int networkAddress) {
-		this.networkAddress = networkAddress;
-	}
+    /**
+     * Returns the network address
+     * 
+     * @return the network address
+     */
+    public int getAddress() {
+        return networkAddress;
+    }
 
-	@Override
-	public
-	String toString() {
-		return networkAddress + "/" + endpoint;
-	}
+    /**
+     * Sets the network address
+     * 
+     * @param networkAddress
+     *            the network address
+     */
+    public void setAddress(int networkAddress) {
+        this.networkAddress = networkAddress;
+    }
+
+    @Override
+    public String toString() {
+        return networkAddress + "/" + endpoint;
+    }
 }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeDeviceAddress.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeDeviceAddress.java
@@ -1,0 +1,47 @@
+package org.bubblecloud.zigbee.v3;
+
+/**
+ * 
+ * @author Chris Jackson
+ *
+ */
+public class ZigBeeDeviceAddress extends ZigBeeAddress {
+	private int networkAddress;
+	private int endpoint;
+	
+	public ZigBeeDeviceAddress(int networkAddress, int endpoint) {
+		this.networkAddress = networkAddress;
+		this.endpoint = endpoint;
+	}
+
+	public ZigBeeDeviceAddress() {
+		// TODO Auto-generated constructor stub
+	}
+
+	@Override
+	public boolean isGroup() {
+		return false;
+	}
+
+	public void setEndpoint(int endpoint) {
+		this.endpoint = endpoint;
+	}
+
+	public int getEndpoint() {
+		return endpoint;
+	}
+
+	public int getAddress() {
+		return networkAddress;
+	}
+
+	public void setAddress(int networkAddress) {
+		this.networkAddress = networkAddress;
+	}
+
+	@Override
+	public
+	String toString() {
+		return networkAddress + "/" + endpoint;
+	}
+}

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeGroupAddress.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeGroupAddress.java
@@ -3,7 +3,7 @@ package org.bubblecloud.zigbee.v3;
 /**
  * ZigBee group.
  */
-public class ZigBeeGroup extends ZigBeeDestination {
+public class ZigBeeGroupAddress extends ZigBeeAddress {
 
     /**
      * The group ID.
@@ -18,7 +18,7 @@ public class ZigBeeGroup extends ZigBeeDestination {
     /**
      * Default constructor.
      */
-    public ZigBeeGroup() {
+    public ZigBeeGroupAddress() {
     }
 
     /**
@@ -26,7 +26,7 @@ public class ZigBeeGroup extends ZigBeeDestination {
      * @param groupId the group ID
      * @param label the group label
      */
-    public ZigBeeGroup(final int groupId, final String label) {
+    public ZigBeeGroupAddress(final int groupId, final String label) {
         this.groupId = groupId;
         this.label = label;
     }
@@ -62,4 +62,9 @@ public class ZigBeeGroup extends ZigBeeDestination {
     public void setLabel(final String label) {
         this.label = label;
     }
+
+	@Override
+	public boolean isGroup() {
+		return true;
+	}
 }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeGroupAddress.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeGroupAddress.java
@@ -23,8 +23,21 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
 
     /**
      * Constructor which sets group ID.
-     * @param groupId the group ID
-     * @param label the group label
+     * 
+     * @param groupId
+     *            the group ID
+     */
+    public ZigBeeGroupAddress(final int groupId) {
+        this.groupId = groupId;
+    }
+
+    /**
+     * Constructor which sets group ID and label.
+     * 
+     * @param groupId
+     *            the group ID
+     * @param label
+     *            the group label
      */
     public ZigBeeGroupAddress(final int groupId, final String label) {
         this.groupId = groupId;
@@ -33,6 +46,7 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
 
     /**
      * Gets group ID.
+     * 
      * @return the group ID.
      */
     public int getGroupId() {
@@ -41,7 +55,9 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
 
     /**
      * Sets group ID.
-     * @param groupId the group ID
+     * 
+     * @param groupId
+     *            the group ID
      */
     public void setGroupId(final int groupId) {
         this.groupId = groupId;
@@ -49,6 +65,7 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
 
     /**
      * Gets group label.
+     * 
      * @return the group label
      */
     public String getLabel() {
@@ -57,14 +74,16 @@ public class ZigBeeGroupAddress extends ZigBeeAddress {
 
     /**
      * Sets group name.
-     * @param label the group label
+     * 
+     * @param label
+     *            the group label
      */
     public void setLabel(final String label) {
         this.label = label;
     }
 
-	@Override
-	public boolean isGroup() {
-		return true;
-	}
+    @Override
+    public boolean isGroup() {
+        return true;
+    }
 }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkDiscoverer.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkDiscoverer.java
@@ -93,8 +93,10 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
         // 0. ZCL command received from remote node. Request IEEE address if it is not yet known.
         if (command instanceof ZclCommand) {
             final ZclCommand zclCommand = (ZclCommand) command;
-            if (networkState.getDevice(zclCommand.getSourceAddress(), zclCommand.getSourceEnpoint()) == null) {
-                requestNodeIeeeAddressAndAssociatedNodes(zclCommand.getSourceAddress());
+            if (networkState.getDevice(zclCommand.getSourceAddress()) == null) {
+            	// TODO: Protect against group address?
+            	ZigBeeDeviceAddress address = (ZigBeeDeviceAddress) zclCommand.getSourceAddress();
+                requestNodeIeeeAddressAndAssociatedNodes(address.getAddress());
             }
         }
 
@@ -262,14 +264,14 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
                                    final NodeDescriptorResponse nodeDescriptorResponse,
                                    final SimpleDescriptorResponse simpleDescriptorResponse) {
         final ZigBeeDevice device;
-        final boolean newDevice = networkState.getDevice(ieeeAddressResponse.getNetworkAddress(),
-                simpleDescriptorResponse.getEndpoint()) == null;
+        final boolean newDevice = networkState.getDevice(new ZigBeeDeviceAddress(ieeeAddressResponse.getNetworkAddress(),
+                simpleDescriptorResponse.getEndpoint())) == null;
 
         if (newDevice) {
             device = new ZigBeeDevice();
         } else {
-            device = networkState.getDevice(ieeeAddressResponse.getNetworkAddress(),
-                    simpleDescriptorResponse.getEndpoint());
+            device = networkState.getDevice(new ZigBeeDeviceAddress(ieeeAddressResponse.getNetworkAddress(),
+                    simpleDescriptorResponse.getEndpoint()));
         }
 
         device.setNetworkAddress(ieeeAddressResponse.getNetworkAddress());

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkDiscoverer.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkDiscoverer.java
@@ -8,16 +8,18 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 /**
- * ZigBee network discoverer is used to discover devices in the network.
- * This class is thread safe.
+ * ZigBee network discoverer is used to discover devices in the network. This
+ * class is thread safe.
  */
 public class ZigBeeNetworkDiscoverer implements CommandListener {
     /**
      * The logger.
      */
-    private final static Logger LOGGER = LoggerFactory.getLogger(ZigBeeNetworkDiscoverer.class);
+    private final static Logger LOGGER = LoggerFactory
+            .getLogger(ZigBeeNetworkDiscoverer.class);
     /**
-     * Minimum time before information can be queried again for same network address or endpoint.
+     * Minimum time before information can be queried again for same network
+     * address or endpoint.
      */
     private static final int MINIMUM_REQUERY_TIME_MILLIS = 10000;
     /**
@@ -31,41 +33,44 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
     /**
      * The received IEEE addresses.
      */
-    private Map<Integer, IeeeAddressResponse> ieeeAddresses =
-            Collections.synchronizedMap(new HashMap<Integer, IeeeAddressResponse>());
+    private Map<Integer, IeeeAddressResponse> ieeeAddresses = Collections
+            .synchronizedMap(new HashMap<Integer, IeeeAddressResponse>());
     /**
      * The received node descriptors.
      */
-    private Map<Integer, NodeDescriptorResponse> nodeDescriptors =
-            Collections.synchronizedMap(new HashMap<Integer, NodeDescriptorResponse>());
+    private Map<Integer, NodeDescriptorResponse> nodeDescriptors = Collections
+            .synchronizedMap(new HashMap<Integer, NodeDescriptorResponse>());
     /**
      * Map of IEEE address request times.
      */
-    final Map<Integer, Long> ieeeAddressRequestTimes =
-            Collections.synchronizedMap(new HashMap<Integer, Long>());
+    final Map<Integer, Long> ieeeAddressRequestTimes = Collections
+            .synchronizedMap(new HashMap<Integer, Long>());
     /**
      * Map of node descriptor request times.
      */
-    final Map<Integer, Long> nodeDescriptorRequestTimes =
-            Collections.synchronizedMap(new HashMap<Integer, Long>());
+    final Map<Integer, Long> nodeDescriptorRequestTimes = Collections
+            .synchronizedMap(new HashMap<Integer, Long>());
     /**
      * Map of active endpoints request times.
      */
-    final Map<Integer, Long> activeEndpointsRequestTimes =
-            Collections.synchronizedMap(new HashMap<Integer, Long>());
+    final Map<Integer, Long> activeEndpointsRequestTimes = Collections
+            .synchronizedMap(new HashMap<Integer, Long>());
     /**
      * Map of endpoint descriptor request times.
      */
-    final Map<String, Long> endpointDescriptorRequestTimes =
-            Collections.synchronizedMap(new HashMap<String, Long>());
+    final Map<String, Long> endpointDescriptorRequestTimes = Collections
+            .synchronizedMap(new HashMap<String, Long>());
 
     /**
      * Discovers ZigBee network state.
-     * @param networkState the network state
-     * @param commandInterface the command interface
+     * 
+     * @param networkState
+     *            the network state
+     * @param commandInterface
+     *            the command interface
      */
     public ZigBeeNetworkDiscoverer(final ZigBeeNetworkState networkState,
-                                   final ZigBeeNetwork commandInterface) {
+            final ZigBeeNetwork commandInterface) {
         this.networkState = networkState;
         this.commandInterface = commandInterface;
     }
@@ -90,12 +95,14 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
     public void commandReceived(final Command command) {
         LOGGER.info("Received: " + command);
 
-        // 0. ZCL command received from remote node. Request IEEE address if it is not yet known.
+        // 0. ZCL command received from remote node. Request IEEE address if it
+        // is not yet known.
         if (command instanceof ZclCommand) {
             final ZclCommand zclCommand = (ZclCommand) command;
             if (networkState.getDevice(zclCommand.getSourceAddress()) == null) {
-            	// TODO: Protect against group address?
-            	ZigBeeDeviceAddress address = (ZigBeeDeviceAddress) zclCommand.getSourceAddress();
+                // TODO: Protect against group address?
+                ZigBeeDeviceAddress address = (ZigBeeDeviceAddress) zclCommand
+                        .getSourceAddress();
                 requestNodeIeeeAddressAndAssociatedNodes(address.getAddress());
             }
         }
@@ -103,7 +110,8 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
         // 0. Node has been announced.
         if (command instanceof DeviceAnnounce) {
             final DeviceAnnounce deviceAnnounce = (DeviceAnnounce) command;
-            requestNodeIeeeAddressAndAssociatedNodes(deviceAnnounce.getNetworkAddress());
+            requestNodeIeeeAddressAndAssociatedNodes(deviceAnnounce
+                    .getNetworkAddress());
         }
 
         // 1. Node IEEE address and associated nodes have been received.
@@ -111,7 +119,8 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
             final IeeeAddressResponse ieeeAddressResponse = (IeeeAddressResponse) command;
 
             if (ieeeAddressResponse.getStatus() == 0) {
-                ieeeAddresses.put(ieeeAddressResponse.getNetworkAddress(), ieeeAddressResponse);
+                ieeeAddresses.put(ieeeAddressResponse.getNetworkAddress(),
+                        ieeeAddressResponse);
                 describeNode(ieeeAddressResponse.getNetworkAddress());
 
                 for (final int networkAddress : ieeeAddressResponse.associatedDeviceList) {
@@ -127,7 +136,8 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
             final NodeDescriptorResponse nodeDescriptorResponse = (NodeDescriptorResponse) command;
 
             if (nodeDescriptorResponse.getStatus() == 0) {
-                nodeDescriptors.put(nodeDescriptorResponse.getNetworkAddress(), nodeDescriptorResponse);
+                nodeDescriptors.put(nodeDescriptorResponse.getNetworkAddress(),
+                        nodeDescriptorResponse);
                 requestNodeEndpoints(nodeDescriptorResponse.getNetworkAddress());
             } else {
                 LOGGER.warn(nodeDescriptorResponse.toString());
@@ -138,8 +148,10 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
         if (command instanceof ActiveEndpointsResponse) {
             final ActiveEndpointsResponse activeEndpointsResponse = (ActiveEndpointsResponse) command;
             if (activeEndpointsResponse.getStatus() == 0) {
-                for (final int endpoint : activeEndpointsResponse.getActiveEndpoints()) {
-                    int networkAddress = activeEndpointsResponse.getNetworkAddress();
+                for (final int endpoint : activeEndpointsResponse
+                        .getActiveEndpoints()) {
+                    int networkAddress = activeEndpointsResponse
+                            .getNetworkAddress();
                     describeEndpoint(networkAddress, endpoint);
                 }
             } else {
@@ -151,15 +163,20 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
         if (command instanceof SimpleDescriptorResponse) {
             final SimpleDescriptorResponse simpleDescriptorResponse = (SimpleDescriptorResponse) command;
             if (simpleDescriptorResponse.getStatus() == 0) {
-                final int networkAddress = simpleDescriptorResponse.getNetworkAddress();
-                final IeeeAddressResponse ieeeAddressResponse = ieeeAddresses.get(networkAddress);
-                final NodeDescriptorResponse nodeDescriptorResponse = nodeDescriptors.get(networkAddress);
+                final int networkAddress = simpleDescriptorResponse
+                        .getNetworkAddress();
+                final IeeeAddressResponse ieeeAddressResponse = ieeeAddresses
+                        .get(networkAddress);
+                final NodeDescriptorResponse nodeDescriptorResponse = nodeDescriptors
+                        .get(networkAddress);
 
-                if (ieeeAddressResponse == null || nodeDescriptorResponse == null) {
+                if (ieeeAddressResponse == null
+                        || nodeDescriptorResponse == null) {
                     return;
                 }
 
-                addOrUpdateDevice(ieeeAddressResponse, nodeDescriptorResponse, simpleDescriptorResponse);
+                addOrUpdateDevice(ieeeAddressResponse, nodeDescriptorResponse,
+                        simpleDescriptorResponse);
             } else {
                 LOGGER.warn(simpleDescriptorResponse.toString());
             }
@@ -168,24 +185,29 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
         // 5. Endpoint user descriptor is received.
         if (command instanceof UserDescriptorResponse) {
             final UserDescriptorResponse userDescriptorResponse = (UserDescriptorResponse) command;
-            LOGGER.info("Received user descriptor response: " + userDescriptorResponse);
+            LOGGER.info("Received user descriptor response: "
+                    + userDescriptorResponse);
         }
     }
 
-
     /**
      * Requests node IEEE address and associated nodes.
-     * @param networkAddress the network address
+     * 
+     * @param networkAddress
+     *            the network address
      */
-    private void requestNodeIeeeAddressAndAssociatedNodes(final int networkAddress) {
-        if (ieeeAddressRequestTimes.get(networkAddress) != null &&
-                System.currentTimeMillis() - ieeeAddressRequestTimes.get(networkAddress) < MINIMUM_REQUERY_TIME_MILLIS) {
+    private void requestNodeIeeeAddressAndAssociatedNodes(
+            final int networkAddress) {
+        if (ieeeAddressRequestTimes.get(networkAddress) != null
+                && System.currentTimeMillis()
+                        - ieeeAddressRequestTimes.get(networkAddress) < MINIMUM_REQUERY_TIME_MILLIS) {
             return;
         }
         ieeeAddressRequestTimes.put(networkAddress, System.currentTimeMillis());
 
         try {
-            final IeeeAddressRequest ieeeAddressRequest = new IeeeAddressRequest(networkAddress, 1, 0);
+            final IeeeAddressRequest ieeeAddressRequest = new IeeeAddressRequest(
+                    networkAddress, 1, 0);
             commandInterface.sendCommand(ieeeAddressRequest);
         } catch (ZigBeeException e) {
             LOGGER.error("Error sending discovery command.", e);
@@ -194,17 +216,22 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
 
     /**
      * Describe node at given network address.
-     * @param networkAddress the network address
+     * 
+     * @param networkAddress
+     *            the network address
      */
     private void describeNode(final int networkAddress) {
-        if (nodeDescriptorRequestTimes.get(networkAddress) != null &&
-                System.currentTimeMillis() - nodeDescriptorRequestTimes.get(networkAddress) < MINIMUM_REQUERY_TIME_MILLIS) {
+        if (nodeDescriptorRequestTimes.get(networkAddress) != null
+                && System.currentTimeMillis()
+                        - nodeDescriptorRequestTimes.get(networkAddress) < MINIMUM_REQUERY_TIME_MILLIS) {
             return;
         }
-        nodeDescriptorRequestTimes.put(networkAddress, System.currentTimeMillis());
+        nodeDescriptorRequestTimes.put(networkAddress,
+                System.currentTimeMillis());
 
         try {
-            final NodeDescriptorRequest nodeDescriptorRequest = new NodeDescriptorRequest(networkAddress, networkAddress);
+            final NodeDescriptorRequest nodeDescriptorRequest = new NodeDescriptorRequest(
+                    networkAddress, networkAddress);
             commandInterface.sendCommand(nodeDescriptorRequest);
         } catch (ZigBeeException e) {
             LOGGER.error("Error sending discovery command.", e);
@@ -213,14 +240,18 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
 
     /**
      * Discover node endpoints.
-     * @param networkAddress the network address
+     * 
+     * @param networkAddress
+     *            the network address
      */
     private void requestNodeEndpoints(final int networkAddress) {
-        if (activeEndpointsRequestTimes.get(networkAddress) != null &&
-                System.currentTimeMillis() - activeEndpointsRequestTimes.get(networkAddress) < MINIMUM_REQUERY_TIME_MILLIS) {
+        if (activeEndpointsRequestTimes.get(networkAddress) != null
+                && System.currentTimeMillis()
+                        - activeEndpointsRequestTimes.get(networkAddress) < MINIMUM_REQUERY_TIME_MILLIS) {
             return;
         }
-        activeEndpointsRequestTimes.put(networkAddress, System.currentTimeMillis());
+        activeEndpointsRequestTimes.put(networkAddress,
+                System.currentTimeMillis());
 
         try {
             final ActiveEndpointsRequest activeEndpointsRequest = new ActiveEndpointsRequest();
@@ -234,16 +265,21 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
 
     /**
      * Describe node endpoint
-     * @param networkAddress the network address
-     * @param endpoint the endpoint
+     * 
+     * @param networkAddress
+     *            the network address
+     * @param endpoint
+     *            the endpoint
      */
     private void describeEndpoint(final int networkAddress, final int endpoint) {
         final String deviceIdentifier = networkAddress + "/" + endpoint;
-        if (endpointDescriptorRequestTimes.get(deviceIdentifier) != null &&
-                System.currentTimeMillis() - endpointDescriptorRequestTimes.get(deviceIdentifier) < MINIMUM_REQUERY_TIME_MILLIS) {
+        if (endpointDescriptorRequestTimes.get(deviceIdentifier) != null
+                && System.currentTimeMillis()
+                        - endpointDescriptorRequestTimes.get(deviceIdentifier) < MINIMUM_REQUERY_TIME_MILLIS) {
             return;
         }
-        endpointDescriptorRequestTimes.put(deviceIdentifier, System.currentTimeMillis());
+        endpointDescriptorRequestTimes.put(deviceIdentifier,
+                System.currentTimeMillis());
         try {
             final SimpleDescriptorRequest request = new SimpleDescriptorRequest();
             request.setDestinationAddress(networkAddress);
@@ -256,21 +292,29 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
 
     /**
      * Adds device to network state.
-     * @param ieeeAddressResponse the IEEE address response
-     * @param nodeDescriptorResponse the node descriptor response
-     * @param simpleDescriptorResponse the simple descriptor response
+     * 
+     * @param ieeeAddressResponse
+     *            the IEEE address response
+     * @param nodeDescriptorResponse
+     *            the node descriptor response
+     * @param simpleDescriptorResponse
+     *            the simple descriptor response
      */
-    private void addOrUpdateDevice(final IeeeAddressResponse ieeeAddressResponse,
-                                   final NodeDescriptorResponse nodeDescriptorResponse,
-                                   final SimpleDescriptorResponse simpleDescriptorResponse) {
+    private void addOrUpdateDevice(
+            final IeeeAddressResponse ieeeAddressResponse,
+            final NodeDescriptorResponse nodeDescriptorResponse,
+            final SimpleDescriptorResponse simpleDescriptorResponse) {
         final ZigBeeDevice device;
-        final boolean newDevice = networkState.getDevice(new ZigBeeDeviceAddress(ieeeAddressResponse.getNetworkAddress(),
-                simpleDescriptorResponse.getEndpoint())) == null;
+        final boolean newDevice = networkState
+                .getDevice(new ZigBeeDeviceAddress(ieeeAddressResponse
+                        .getNetworkAddress(), simpleDescriptorResponse
+                        .getEndpoint())) == null;
 
         if (newDevice) {
             device = new ZigBeeDevice();
         } else {
-            device = networkState.getDevice(new ZigBeeDeviceAddress(ieeeAddressResponse.getNetworkAddress(),
+            device = networkState.getDevice(new ZigBeeDeviceAddress(
+                    ieeeAddressResponse.getNetworkAddress(),
                     simpleDescriptorResponse.getEndpoint()));
         }
 
@@ -292,12 +336,12 @@ public class ZigBeeNetworkDiscoverer implements CommandListener {
         }
 
         /*
-        final UserDescriptorRequest userDescriptorRequest = new UserDescriptorRequest(
-                device.getNetworkAddress(), device.getNetworkAddress());
-        try {
-            commandInterface.sendCommand(userDescriptorRequest);
-        } catch (final ZigBeeException e) {
-            LOGGER.error("Error sending discovery command.", e);
-        }*/
+         * final UserDescriptorRequest userDescriptorRequest = new
+         * UserDescriptorRequest( device.getNetworkAddress(),
+         * device.getNetworkAddress()); try {
+         * commandInterface.sendCommand(userDescriptorRequest); } catch (final
+         * ZigBeeException e) { LOGGER.error("Error sending discovery command.",
+         * e); }
+         */
     }
 }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkState.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkState.java
@@ -10,13 +10,13 @@ public interface ZigBeeNetworkState {
      * Adds group.
      * @param group the group to add
      */
-    void addGroup(ZigBeeGroup group);
+    void addGroup(ZigBeeGroupAddress group);
 
     /**
      * Updates group.
      * @param group the group to update
      */
-    void updateGroup(ZigBeeGroup group);
+    void updateGroup(ZigBeeGroupAddress group);
 
     /**
      * Removes group by network address.
@@ -29,13 +29,13 @@ public interface ZigBeeNetworkState {
      * @param groupId the group ID
      * @return the ZigBee group or null if no exists with given group ID.
      */
-    ZigBeeGroup getGroup(int groupId);
+    ZigBeeGroupAddress getGroup(int groupId);
 
     /**
      * Gets all groups.
      * @return list of groups.
      */
-    List<ZigBeeGroup> getGroups();
+    List<ZigBeeGroupAddress> getGroups();
 
     /**
      * Adds device.
@@ -57,10 +57,10 @@ public interface ZigBeeNetworkState {
 
     /**
      * Gets device by network address.
-     * @param networkAddress the network address
+     * @param zigBeeDestination the network address
      * @return the ZigBee device or null if no exists with given network address.
      */
-    ZigBeeDevice getDevice(int networkAddress, int endpoint);
+    ZigBeeDevice getDevice(ZigBeeAddress zigBeeDestination);
 
     /**
      * Gets all devices.

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkStateImpl.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkStateImpl.java
@@ -15,7 +15,8 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
     /**
      * The logger.
      */
-    private final static Logger LOGGER = LoggerFactory.getLogger(ZigBeeNetworkStateImpl.class);
+    private final static Logger LOGGER = LoggerFactory
+            .getLogger(ZigBeeNetworkStateImpl.class);
     /**
      * The devices in the ZigBee network.
      */
@@ -27,8 +28,8 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
     /**
      * The listeners of the ZigBee network.
      */
-    private List<ZigBeeNetworkStateListener> listeners = Collections.unmodifiableList(
-            new ArrayList<ZigBeeNetworkStateListener>());
+    private List<ZigBeeNetworkStateListener> listeners = Collections
+            .unmodifiableList(new ArrayList<ZigBeeNetworkStateListener>());
     /**
      * The network reset flag.
      */
@@ -41,7 +42,9 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
     /**
      * Constructor which configures whether network shoule be reset at startup
      * or loaded from serialized file.
-     * @param resetNetwork the network reset flag
+     * 
+     * @param resetNetwork
+     *            the network reset flag
      */
     public ZigBeeNetworkStateImpl(boolean resetNetwork) {
         this.resetNetwork = resetNetwork;
@@ -57,9 +60,11 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
             LOGGER.info("Loading network state...");
             final String networkStateString;
             try {
-                networkStateString = FileUtils.readFileToString(networkStateFile);
+                networkStateString = FileUtils
+                        .readFileToString(networkStateFile);
             } catch (final IOException e) {
-                LOGGER.error("Error loading network state from file: " + networkStateFile.getAbsolutePath());
+                LOGGER.error("Error loading network state from file: "
+                        + networkStateFile.getAbsolutePath());
                 return;
             }
             final ZigBeeNetworkStateSerializer serializer = new ZigBeeNetworkStateSerializer();
@@ -76,9 +81,11 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
         final ZigBeeNetworkStateSerializer serializer = new ZigBeeNetworkStateSerializer();
         final File networkStateFile = new File(networkStateFilePath);
         try {
-            FileUtils.writeStringToFile(networkStateFile, serializer.serialize(this), false);
+            FileUtils.writeStringToFile(networkStateFile,
+                    serializer.serialize(this), false);
         } catch (final IOException e) {
-            LOGGER.error("Error loading network state from file: " + networkStateFile.getAbsolutePath());
+            LOGGER.error("Error loading network state from file: "
+                    + networkStateFile.getAbsolutePath());
             return;
         }
         LOGGER.info("ZigBeeApi saving network state done.");
@@ -120,12 +127,12 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
         }
     }
 
-
-
     @Override
     public void addDevice(final ZigBeeDevice device) {
         synchronized (devices) {
-            devices.put(device.getNetworkAddress() + "/" + device.getEndpoint(), device);
+            devices.put(
+                    device.getNetworkAddress() + "/" + device.getEndpoint(),
+                    device);
         }
         synchronized (this) {
             for (final ZigBeeNetworkStateListener listener : listeners) {
@@ -148,12 +155,12 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
 
     @Override
     public ZigBeeDevice getDevice(final ZigBeeAddress networkAddress) {
-    	if(networkAddress.isGroup()) {
-    		return null;
-    	}
-    	
+        if (networkAddress.isGroup()) {
+            return null;
+        }
+
         synchronized (devices) {
-        	// TODO Maybe this should just use the network address as the key?
+            // TODO Maybe this should just use the network address as the key?
             return devices.get(networkAddress.toString());
         }
     }
@@ -181,7 +188,8 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
     }
 
     @Override
-    public void addNetworkListener(final ZigBeeNetworkStateListener networkListener) {
+    public void addNetworkListener(
+            final ZigBeeNetworkStateListener networkListener) {
         synchronized (this) {
             final List<ZigBeeNetworkStateListener> modifiedListeners = new ArrayList<ZigBeeNetworkStateListener>(
                     listeners);
@@ -191,7 +199,8 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
     }
 
     @Override
-    public void removeNetworkListener(final ZigBeeNetworkStateListener networkListener) {
+    public void removeNetworkListener(
+            final ZigBeeNetworkStateListener networkListener) {
         synchronized (this) {
             final List<ZigBeeNetworkStateListener> modifiedListeners = new ArrayList<ZigBeeNetworkStateListener>(
                     listeners);

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkStateImpl.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkStateImpl.java
@@ -23,7 +23,7 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
     /**
      * The groups in the ZigBee network.
      */
-    private Map<Integer, ZigBeeGroup> groups = new TreeMap<Integer, ZigBeeGroup>();
+    private Map<Integer, ZigBeeGroupAddress> groups = new TreeMap<Integer, ZigBeeGroupAddress>();
     /**
      * The listeners of the ZigBee network.
      */
@@ -85,21 +85,21 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
     }
 
     @Override
-    public void addGroup(final ZigBeeGroup group) {
+    public void addGroup(final ZigBeeGroupAddress group) {
         synchronized (groups) {
             groups.put(group.getGroupId(), group);
         }
     }
 
     @Override
-    public void updateGroup(ZigBeeGroup group) {
+    public void updateGroup(ZigBeeGroupAddress group) {
         synchronized (groups) {
             groups.put(group.getGroupId(), group);
         }
     }
 
     @Override
-    public ZigBeeGroup getGroup(final int groupId) {
+    public ZigBeeGroupAddress getGroup(final int groupId) {
         synchronized (groups) {
             return groups.get(groupId);
         }
@@ -107,16 +107,16 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
 
     @Override
     public void removeGroup(final int groupId) {
-        final ZigBeeGroup group;
+        final ZigBeeGroupAddress group;
         synchronized (groups) {
             group = groups.remove(groupId);
         }
     }
 
     @Override
-    public List<ZigBeeGroup> getGroups() {
+    public List<ZigBeeGroupAddress> getGroups() {
         synchronized (groups) {
-            return new ArrayList<ZigBeeGroup>(groups.values());
+            return new ArrayList<ZigBeeGroupAddress>(groups.values());
         }
     }
 
@@ -137,7 +137,7 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
     @Override
     public void updateDevice(ZigBeeDevice device) {
         synchronized (devices) {
-            devices.put(device.getNetworkAddress() + "/" + device.getEndpoint(), device);
+            devices.put(device.getDeviceAddress().toString(), device);
         }
         synchronized (this) {
             for (final ZigBeeNetworkStateListener listener : listeners) {
@@ -147,9 +147,14 @@ public class ZigBeeNetworkStateImpl implements ZigBeeNetworkState {
     }
 
     @Override
-    public ZigBeeDevice getDevice(final int networkAddress, int endpoint) {
+    public ZigBeeDevice getDevice(final ZigBeeAddress networkAddress) {
+    	if(networkAddress.isGroup()) {
+    		return null;
+    	}
+    	
         synchronized (devices) {
-            return devices.get(networkAddress + "/" + endpoint);
+        	// TODO Maybe this should just use the network address as the key?
+            return devices.get(networkAddress.toString());
         }
     }
 

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkStateSerializer.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkStateSerializer.java
@@ -20,8 +20,9 @@ public class ZigBeeNetworkStateSerializer {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enableDefaultTyping();
         objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
-        final List<ZigBeeDestination> destinations = new ArrayList<ZigBeeDestination>();
-        destinations.addAll(networkState.getDevices());
+        final List<ZigBeeAddress> destinations = new ArrayList<ZigBeeAddress>();
+        // TODO!!!!
+//        destinations.addAll(networkState.getDevices());
         destinations.addAll(networkState.getGroups());
         try {
             return objectMapper.writeValueAsString(destinations);
@@ -36,20 +37,22 @@ public class ZigBeeNetworkStateSerializer {
      * @param networkStateString the network state as {@link String}
      */
     public void deserialize(final ZigBeeNetworkState networkState, final String networkStateString) {
+    	if(true) return;
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enableDefaultTyping();
         objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
-        final List<ZigBeeDestination> devices;
+        final List<ZigBeeAddress> devices;
         try {
             devices = objectMapper.readValue(networkStateString, ArrayList.class);
         } catch (final IOException e) {
             throw new RuntimeException("Error serializing network state.", e);
         }
-        for (final ZigBeeDestination destination : devices) {
+        for (final ZigBeeAddress destination : devices) {
             if (destination.isGroup()) {
-                networkState.addGroup((ZigBeeGroup) destination);
+                networkState.addGroup((ZigBeeGroupAddress) destination);
             } else {
-                networkState.addDevice((ZigBeeDevice) destination);
+                // TODO!!!!
+//                networkState.addDevice((ZigBeeDevice) destination);
             }
         }
     }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkStateSerializer.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeNetworkStateSerializer.java
@@ -20,9 +20,8 @@ public class ZigBeeNetworkStateSerializer {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enableDefaultTyping();
         objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
-        final List<ZigBeeAddress> destinations = new ArrayList<ZigBeeAddress>();
-        // TODO!!!!
-//        destinations.addAll(networkState.getDevices());
+        final List<Object> destinations = new ArrayList<Object>();
+        destinations.addAll(networkState.getDevices());
         destinations.addAll(networkState.getGroups());
         try {
             return objectMapper.writeValueAsString(destinations);
@@ -37,22 +36,20 @@ public class ZigBeeNetworkStateSerializer {
      * @param networkStateString the network state as {@link String}
      */
     public void deserialize(final ZigBeeNetworkState networkState, final String networkStateString) {
-    	if(true) return;
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enableDefaultTyping();
         objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
-        final List<ZigBeeAddress> devices;
+        final List<Object> devices;
         try {
             devices = objectMapper.readValue(networkStateString, ArrayList.class);
         } catch (final IOException e) {
             throw new RuntimeException("Error serializing network state.", e);
         }
-        for (final ZigBeeAddress destination : devices) {
-            if (destination.isGroup()) {
+        for (final Object destination : devices) {
+            if (destination instanceof ZigBeeGroupAddress) {
                 networkState.addGroup((ZigBeeGroupAddress) destination);
             } else {
-                // TODO!!!!
-//                networkState.addDevice((ZigBeeDevice) destination);
+                networkState.addDevice((ZigBeeDevice) destination);
             }
         }
     }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/rpc/ZigBeeRpcApi.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/rpc/ZigBeeRpcApi.java
@@ -3,7 +3,7 @@ package org.bubblecloud.zigbee.v3.rpc;
 import org.bubblecloud.zigbee.v3.Command;
 import org.bubblecloud.zigbee.v3.ZigBeeDevice;
 import org.bubblecloud.zigbee.v3.ZigBeeException;
-import org.bubblecloud.zigbee.v3.ZigBeeGroup;
+import org.bubblecloud.zigbee.v3.ZigBeeGroupAddress;
 
 import java.util.List;
 
@@ -90,12 +90,12 @@ public interface ZigBeeRpcApi {
      * @param groupId the group ID
      * @return the ZigBee group or null if no exists with given group ID.
      */
-    ZigBeeGroup getGroup(int groupId);
+    ZigBeeGroupAddress getGroup(int groupId);
 
     /**
      * Gets all groups.
      * @return list of groups.
      */
-    List<ZigBeeGroup> getGroups();
+    List<ZigBeeGroupAddress> getGroups();
 
 }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommand.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommand.java
@@ -21,10 +21,6 @@ public class ZclCommand extends Command {
      */
     private ZigBeeAddress destinationAddress;
     /**
-     * The destination group ID which can be used instead of destination address and endpoint.
-     */
-//    private Integer destinationGroupId;
-    /**
      * The type.
      */
     private ZclCommandType type;
@@ -50,10 +46,7 @@ public class ZclCommand extends Command {
      */
     public ZclCommand(final ZclCommandMessage commandMessage) {
         this.sourceAddress = commandMessage.getSourceAddress();
-//        this.sourceEnpoint = commandMessage.getSourceEnpoint();
         this.destinationAddress = commandMessage.getDestinationAddress();
-//        this.destinationEndpoint = commandMessage.getDestinationEndpoint();
-//        this.destinationGroupId = commandMessage.getDestinationGroupId();
         this.type = commandMessage.getType();
         this.clusterId = commandMessage.getClusterId();
         this.transactionId = commandMessage.getTransactionId();
@@ -92,38 +85,6 @@ public class ZclCommand extends Command {
     }
 
     /**
-     * Gets destination endpoint.
-     * @return the destination endpoint
-     */
-//    public ZigBeeDestination getDestinationEndpoint() {
-  //      return destinationEndpoint;
-    //}
-
-    /**
-     * Sets destination endpoint
-     * @param destinationEndpoint the destination endpoint
-     */
-//    public void setDestinationEndpoint(final int destinationEndpoint) {
-  //      this.destinationEndpoint = destinationEndpoint;
-    //}
-
-    /**
-     * Gets destination group ID
-     * @return the destination group ID
-     */
-//    public Integer getDestinationGroupId() {
-  //      return destinationGroupId;
-    //}
-
-    /**
-     * Sets destination group ID
-     * @param destinationGroupId the destination group ID
-     */
-//    public void setDestinationGroupId(final Integer destinationGroupId) {
-  //      this.destinationGroupId = destinationGroupId;
-    //}
-
-    /**
      * Gets source address.
      * @return the source address
      */
@@ -138,22 +99,6 @@ public class ZclCommand extends Command {
     public void setSourceAddress(final ZigBeeAddress sourceAddress) {
         this.sourceAddress = sourceAddress;
     }
-
-    /**
-     * Gets source endpoint.
-     * @return the source endpoint
-     */
-//    public int getSourceEnpoint() {
-  //      return sourceEnpoint;
-    //}
-
-    /**
-     * Sets source endpoint.
-     * @param sourceEnpoint the source endpoint
-     */
-//    public void setSourceEnpoint(final int sourceEnpoint) {
-  //      this.sourceEnpoint = sourceEnpoint;
-    //}
 
     /**
      * Gets the cluster ID for generic messages.
@@ -194,10 +139,7 @@ public class ZclCommand extends Command {
     public ZclCommandMessage toCommandMessage() {
         final ZclCommandMessage commandMessage = new ZclCommandMessage();
         commandMessage.setSourceAddress(sourceAddress);
-//        commandMessage.setSourceEnpoint(sourceEnpoint);
         commandMessage.setDestinationAddress(destinationAddress);
-//        commandMessage.setDestinationEndpoint(destinationEndpoint);
-//        commandMessage.setDestinationGroupId(destinationGroupId);
         commandMessage.setType(type);
         commandMessage.setClusterId(clusterId);
         commandMessage.setTransactionId(transactionId);

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommand.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommand.java
@@ -1,6 +1,7 @@
 package org.bubblecloud.zigbee.v3.zcl;
 
 import org.bubblecloud.zigbee.v3.Command;
+import org.bubblecloud.zigbee.v3.ZigBeeAddress;
 import org.bubblecloud.zigbee.v3.zcl.protocol.ZclClusterType;
 import org.bubblecloud.zigbee.v3.zcl.protocol.ZclCommandType;
 
@@ -8,28 +9,21 @@ import org.bubblecloud.zigbee.v3.zcl.protocol.ZclCommandType;
  * Base class for value object classes holding ZCL commands.
  *
  * @author Tommi S.E. Laukkanen
+ * @author Chris Jackson
  */
 public class ZclCommand extends Command {
     /**
      * The source address.
      */
-    private int sourceAddress;
-    /**
-     * The source endpoint.
-     */
-    private int sourceEnpoint;
+    private ZigBeeAddress sourceAddress;
     /**
      * The destination address.
      */
-    private int destinationAddress;
-    /**
-     * The destination endpoint.
-     */
-    private int destinationEndpoint;
+    private ZigBeeAddress destinationAddress;
     /**
      * The destination group ID which can be used instead of destination address and endpoint.
      */
-    private Integer destinationGroupId;
+//    private Integer destinationGroupId;
     /**
      * The type.
      */
@@ -56,10 +50,10 @@ public class ZclCommand extends Command {
      */
     public ZclCommand(final ZclCommandMessage commandMessage) {
         this.sourceAddress = commandMessage.getSourceAddress();
-        this.sourceEnpoint = commandMessage.getSourceEnpoint();
+//        this.sourceEnpoint = commandMessage.getSourceEnpoint();
         this.destinationAddress = commandMessage.getDestinationAddress();
-        this.destinationEndpoint = commandMessage.getDestinationEndpoint();
-        this.destinationGroupId = commandMessage.getDestinationGroupId();
+//        this.destinationEndpoint = commandMessage.getDestinationEndpoint();
+//        this.destinationGroupId = commandMessage.getDestinationGroupId();
         this.type = commandMessage.getType();
         this.clusterId = commandMessage.getClusterId();
         this.transactionId = commandMessage.getTransactionId();
@@ -85,7 +79,7 @@ public class ZclCommand extends Command {
      * Gets destination address.
      * @return the destination address.
      */
-    public int getDestinationAddress() {
+    public ZigBeeAddress getDestinationAddress() {
         return destinationAddress;
     }
 
@@ -93,7 +87,7 @@ public class ZclCommand extends Command {
      * Sets destination address.
      * @param destinationAddress the destination address.
      */
-    public void setDestinationAddress(final int destinationAddress) {
+    public void setDestinationAddress(final ZigBeeAddress destinationAddress) {
         this.destinationAddress = destinationAddress;
     }
 
@@ -101,39 +95,39 @@ public class ZclCommand extends Command {
      * Gets destination endpoint.
      * @return the destination endpoint
      */
-    public int getDestinationEndpoint() {
-        return destinationEndpoint;
-    }
+//    public ZigBeeDestination getDestinationEndpoint() {
+  //      return destinationEndpoint;
+    //}
 
     /**
      * Sets destination endpoint
      * @param destinationEndpoint the destination endpoint
      */
-    public void setDestinationEndpoint(final int destinationEndpoint) {
-        this.destinationEndpoint = destinationEndpoint;
-    }
+//    public void setDestinationEndpoint(final int destinationEndpoint) {
+  //      this.destinationEndpoint = destinationEndpoint;
+    //}
 
     /**
      * Gets destination group ID
      * @return the destination group ID
      */
-    public Integer getDestinationGroupId() {
-        return destinationGroupId;
-    }
+//    public Integer getDestinationGroupId() {
+  //      return destinationGroupId;
+    //}
 
     /**
      * Sets destination group ID
      * @param destinationGroupId the destination group ID
      */
-    public void setDestinationGroupId(final Integer destinationGroupId) {
-        this.destinationGroupId = destinationGroupId;
-    }
+//    public void setDestinationGroupId(final Integer destinationGroupId) {
+  //      this.destinationGroupId = destinationGroupId;
+    //}
 
     /**
      * Gets source address.
      * @return the source address
      */
-    public int getSourceAddress() {
+    public ZigBeeAddress getSourceAddress() {
         return sourceAddress;
     }
 
@@ -141,7 +135,7 @@ public class ZclCommand extends Command {
      * Sets source address.
      * @param sourceAddress the source address
      */
-    public void setSourceAddress(final int sourceAddress) {
+    public void setSourceAddress(final ZigBeeAddress sourceAddress) {
         this.sourceAddress = sourceAddress;
     }
 
@@ -149,17 +143,17 @@ public class ZclCommand extends Command {
      * Gets source endpoint.
      * @return the source endpoint
      */
-    public int getSourceEnpoint() {
-        return sourceEnpoint;
-    }
+//    public int getSourceEnpoint() {
+  //      return sourceEnpoint;
+    //}
 
     /**
      * Sets source endpoint.
      * @param sourceEnpoint the source endpoint
      */
-    public void setSourceEnpoint(final int sourceEnpoint) {
-        this.sourceEnpoint = sourceEnpoint;
-    }
+//    public void setSourceEnpoint(final int sourceEnpoint) {
+  //      this.sourceEnpoint = sourceEnpoint;
+    //}
 
     /**
      * Gets the cluster ID for generic messages.
@@ -200,10 +194,10 @@ public class ZclCommand extends Command {
     public ZclCommandMessage toCommandMessage() {
         final ZclCommandMessage commandMessage = new ZclCommandMessage();
         commandMessage.setSourceAddress(sourceAddress);
-        commandMessage.setSourceEnpoint(sourceEnpoint);
+//        commandMessage.setSourceEnpoint(sourceEnpoint);
         commandMessage.setDestinationAddress(destinationAddress);
-        commandMessage.setDestinationEndpoint(destinationEndpoint);
-        commandMessage.setDestinationGroupId(destinationGroupId);
+//        commandMessage.setDestinationEndpoint(destinationEndpoint);
+//        commandMessage.setDestinationGroupId(destinationGroupId);
         commandMessage.setType(type);
         commandMessage.setClusterId(clusterId);
         commandMessage.setTransactionId(transactionId);
@@ -217,8 +211,8 @@ public class ZclCommand extends Command {
             resolvedClusterId = type.getClusterType().getId();
         }
         return ZclClusterType.getValueById(resolvedClusterId).getLabel() + " - " + type + " "
-                + sourceAddress + "." + sourceEnpoint + " -> "
-                + destinationAddress + "." + destinationEndpoint + " tid=" + transactionId;
+                + sourceAddress + " -> "
+                + destinationAddress + " tid=" + transactionId;
     }
 
 }

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommandMessage.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommandMessage.java
@@ -15,6 +15,7 @@
  */
 package org.bubblecloud.zigbee.v3.zcl;
 
+import org.bubblecloud.zigbee.v3.ZigBeeAddress;
 import org.bubblecloud.zigbee.v3.zcl.protocol.ZclClusterType;
 import org.bubblecloud.zigbee.v3.zcl.protocol.ZclCommandType;
 import org.bubblecloud.zigbee.v3.zcl.protocol.ZclCommandTypeRegistrar;
@@ -32,19 +33,19 @@ public class ZclCommandMessage {
     /**
      * The source address.
      */
-    private int sourceAddress;
+    private ZigBeeAddress sourceAddress;
     /**
      * The source endpoint.
      */
-    private int sourceEnpoint;
+//    private int sourceEnpoint;
     /**
      * The destination address.
      */
-    private int destinationAddress;
+    private ZigBeeAddress destinationAddress;
     /**
      * The destination endpoint.
      */
-    private int destinationEndpoint;
+//    private int destinationEndpoint;
     /**
      * The destination group ID which can be used instead of destination address and endpoint.
      */
@@ -91,7 +92,7 @@ public class ZclCommandMessage {
      * Gets destination address.
      * @return the destination address.
      */
-    public int getDestinationAddress() {
+    public ZigBeeAddress getDestinationAddress() {
         return destinationAddress;
     }
 
@@ -99,7 +100,7 @@ public class ZclCommandMessage {
      * Sets destination address.
      * @param destinationAddress the destination address.
      */
-    public void setDestinationAddress(final int destinationAddress) {
+    public void setDestinationAddress(final ZigBeeAddress destinationAddress) {
         this.destinationAddress = destinationAddress;
     }
 
@@ -107,17 +108,17 @@ public class ZclCommandMessage {
      * Gets destination endpoint.
      * @return the destination endpoint
      */
-    public int getDestinationEndpoint() {
-        return destinationEndpoint;
-    }
+//    public int getDestinationEndpoint() {
+  //      return destinationEndpoint;
+    //}
 
     /**
      * Sets destination endpoint
      * @param destinationEndpoint the destination endpoint
      */
-    public void setDestinationEndpoint(final int destinationEndpoint) {
-        this.destinationEndpoint = destinationEndpoint;
-    }
+//    public void setDestinationEndpoint(final int destinationEndpoint) {
+  //      this.destinationEndpoint = destinationEndpoint;
+    //}
 
     /**
      * Gets destination group ID
@@ -155,7 +156,7 @@ public class ZclCommandMessage {
      * Gets source address.
      * @return the source address
      */
-    public int getSourceAddress() {
+    public ZigBeeAddress getSourceAddress() {
         return sourceAddress;
     }
 
@@ -163,7 +164,7 @@ public class ZclCommandMessage {
      * Sets source address.
      * @param sourceAddress the source address
      */
-    public void setSourceAddress(final int sourceAddress) {
+    public void setSourceAddress(final ZigBeeAddress sourceAddress) {
         this.sourceAddress = sourceAddress;
     }
 
@@ -171,16 +172,16 @@ public class ZclCommandMessage {
      * Gets source endpoint.
      * @return the source endpoint
      */
-    public int getSourceEnpoint() {
-        return sourceEnpoint;
-    }
+//    public int getSourceEnpoint() {
+  //      return sourceEnpoint;
+    //}
 
     /**
      * Sets source endpoint.
      * @param sourceEnpoint the source endpoint
      */
-    public void setSourceEnpoint(final int sourceEnpoint) {
-        this.sourceEnpoint = sourceEnpoint;
+    public void setSourceEndpoint(final int sourceEnpoint) {
+//        this.sourceEnpoint = sourceEnpoint;
     }
 
     /**
@@ -218,11 +219,20 @@ public class ZclCommandMessage {
     @Override
     public String toString() {
         Integer resolvedClusterId = getClusterId();
-        if (resolvedClusterId == null) {
+        StringBuilder sb = new StringBuilder();
+        if (resolvedClusterId == null && type != null) {
             resolvedClusterId = type.getClusterType().getId();
+            
+            sb.append(ZclClusterType.getValueById(resolvedClusterId).getLabel() + " - " + type + " ");
         }
-        return ZclClusterType.getValueById(resolvedClusterId).getLabel() + " - " + type + " " + sourceAddress + "." + sourceEnpoint + " -> "
-                + destinationAddress + "." + destinationEndpoint  + " tid=" + transactionId + " " + fields;
+        else {
+        	sb.append("ZCL unknown ");
+        }
+        
+        sb.append(sourceAddress + " -> "
+                + destinationAddress  + " tid=" + transactionId + " " + fields);
+        
+        return sb.toString();
     }
 
     static {

--- a/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommandMessage.java
+++ b/zigbee-common/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommandMessage.java
@@ -16,6 +16,7 @@
 package org.bubblecloud.zigbee.v3.zcl;
 
 import org.bubblecloud.zigbee.v3.ZigBeeAddress;
+import org.bubblecloud.zigbee.v3.ZigBeeGroupAddress;
 import org.bubblecloud.zigbee.v3.zcl.protocol.ZclClusterType;
 import org.bubblecloud.zigbee.v3.zcl.protocol.ZclCommandType;
 import org.bubblecloud.zigbee.v3.zcl.protocol.ZclCommandTypeRegistrar;
@@ -35,21 +36,9 @@ public class ZclCommandMessage {
      */
     private ZigBeeAddress sourceAddress;
     /**
-     * The source endpoint.
-     */
-//    private int sourceEnpoint;
-    /**
      * The destination address.
      */
     private ZigBeeAddress destinationAddress;
-    /**
-     * The destination endpoint.
-     */
-//    private int destinationEndpoint;
-    /**
-     * The destination group ID which can be used instead of destination address and endpoint.
-     */
-    private Integer destinationGroupId;
     /**
      * The type.
      */
@@ -66,6 +55,7 @@ public class ZclCommandMessage {
      * The fields and their values.
      */
     Map<ZclFieldType, Object> fields = new TreeMap<ZclFieldType, Object>();
+
     /**
      * Default constructor for inbound messages.
      */
@@ -74,6 +64,7 @@ public class ZclCommandMessage {
 
     /**
      * Gets the type
+     * 
      * @return the type
      */
     public ZclCommandType getType() {
@@ -82,7 +73,9 @@ public class ZclCommandMessage {
 
     /**
      * Sets the command
-     * @param type the command
+     * 
+     * @param type
+     *            the command
      */
     public void setType(final ZclCommandType type) {
         this.type = type;
@@ -90,6 +83,7 @@ public class ZclCommandMessage {
 
     /**
      * Gets destination address.
+     * 
      * @return the destination address.
      */
     public ZigBeeAddress getDestinationAddress() {
@@ -98,46 +92,39 @@ public class ZclCommandMessage {
 
     /**
      * Sets destination address.
-     * @param destinationAddress the destination address.
+     * 
+     * @param destinationAddress
+     *            the destination address.
      */
     public void setDestinationAddress(final ZigBeeAddress destinationAddress) {
         this.destinationAddress = destinationAddress;
     }
 
     /**
-     * Gets destination endpoint.
-     * @return the destination endpoint
-     */
-//    public int getDestinationEndpoint() {
-  //      return destinationEndpoint;
-    //}
-
-    /**
-     * Sets destination endpoint
-     * @param destinationEndpoint the destination endpoint
-     */
-//    public void setDestinationEndpoint(final int destinationEndpoint) {
-  //      this.destinationEndpoint = destinationEndpoint;
-    //}
-
-    /**
      * Gets destination group ID
+     * 
      * @return the destination group ID
      */
     public Integer getDestinationGroupId() {
-        return destinationGroupId;
+        if (destinationAddress instanceof ZigBeeGroupAddress) {
+            return ((ZigBeeGroupAddress) destinationAddress).getGroupId();
+        }
+        return 0;
     }
 
     /**
      * Sets destination group ID
-     * @param destinationGroupId the destination group ID
+     * 
+     * @param destinationGroupId
+     *            the destination group ID
      */
     public void setDestinationGroupId(final Integer destinationGroupId) {
-        this.destinationGroupId = destinationGroupId;
+        this.destinationAddress = new ZigBeeGroupAddress(destinationGroupId);
     }
 
     /**
      * Gets the fields
+     * 
      * @return the fields
      */
     public Map<ZclFieldType, Object> getFields() {
@@ -146,7 +133,9 @@ public class ZclCommandMessage {
 
     /**
      * Sets the fields.
-     * @param fields the fields
+     * 
+     * @param fields
+     *            the fields
      */
     public void setFields(final Map<ZclFieldType, Object> fields) {
         this.fields = fields;
@@ -154,6 +143,7 @@ public class ZclCommandMessage {
 
     /**
      * Gets source address.
+     * 
      * @return the source address
      */
     public ZigBeeAddress getSourceAddress() {
@@ -162,30 +152,17 @@ public class ZclCommandMessage {
 
     /**
      * Sets source address.
-     * @param sourceAddress the source address
+     * 
+     * @param sourceAddress
+     *            the source address
      */
     public void setSourceAddress(final ZigBeeAddress sourceAddress) {
         this.sourceAddress = sourceAddress;
     }
 
     /**
-     * Gets source endpoint.
-     * @return the source endpoint
-     */
-//    public int getSourceEnpoint() {
-  //      return sourceEnpoint;
-    //}
-
-    /**
-     * Sets source endpoint.
-     * @param sourceEnpoint the source endpoint
-     */
-    public void setSourceEndpoint(final int sourceEnpoint) {
-//        this.sourceEnpoint = sourceEnpoint;
-    }
-
-    /**
      * Gets the cluster ID for generic messages.
+     * 
      * @return the cluster ID.
      */
     public Integer getClusterId() {
@@ -194,7 +171,9 @@ public class ZclCommandMessage {
 
     /**
      * Sets the cluster ID for generic messages.
-     * @param clusterId the cluster ID
+     * 
+     * @param clusterId
+     *            the cluster ID
      */
     public void setClusterId(Integer clusterId) {
         this.clusterId = clusterId;
@@ -202,6 +181,7 @@ public class ZclCommandMessage {
 
     /**
      * Gets the transaction ID.
+     * 
      * @return the transaction ID
      */
     public Byte getTransactionId() {
@@ -210,7 +190,9 @@ public class ZclCommandMessage {
 
     /**
      * Sets the transaction ID.
-     * @param transactionId the transaction ID
+     * 
+     * @param transactionId
+     *            the transaction ID
      */
     public void setTransactionId(final Byte transactionId) {
         this.transactionId = transactionId;
@@ -222,16 +204,16 @@ public class ZclCommandMessage {
         StringBuilder sb = new StringBuilder();
         if (resolvedClusterId == null && type != null) {
             resolvedClusterId = type.getClusterType().getId();
-            
-            sb.append(ZclClusterType.getValueById(resolvedClusterId).getLabel() + " - " + type + " ");
+
+            sb.append(ZclClusterType.getValueById(resolvedClusterId).getLabel()
+                    + " - " + type + " ");
+        } else {
+            sb.append("ZCL unknown ");
         }
-        else {
-        	sb.append("ZCL unknown ");
-        }
-        
-        sb.append(sourceAddress + " -> "
-                + destinationAddress  + " tid=" + transactionId + " " + fields);
-        
+
+        sb.append(sourceAddress + " -> " + destinationAddress + " tid="
+                + transactionId + " " + fields);
+
         return sb.toString();
     }
 

--- a/zigbee-dongle-cc2531/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommandTransmitter.java
+++ b/zigbee-dongle-cc2531/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommandTransmitter.java
@@ -22,6 +22,7 @@ import org.bubblecloud.zigbee.network.ClusterMessage;
 import org.bubblecloud.zigbee.network.packet.ResponseStatus;
 import org.bubblecloud.zigbee.network.packet.af.*;
 import org.bubblecloud.zigbee.v3.CommandListener;
+import org.bubblecloud.zigbee.v3.ZigBeeAddress;
 import org.bubblecloud.zigbee.v3.ZigBeeDeviceAddress;
 import org.bubblecloud.zigbee.network.impl.*;
 import org.bubblecloud.zigbee.v3.ZigBeeException;
@@ -40,11 +41,13 @@ import java.util.List;
  *
  * @author Tommi S.E. Laukkanen
  */
-public class ZclCommandTransmitter implements ApplicationFrameworkMessageListener {
+public class ZclCommandTransmitter implements
+        ApplicationFrameworkMessageListener {
     /**
      * The logger.
      */
-    private static final Logger LOGGER = LoggerFactory.getLogger(ZclCommandTransmitter.class);
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(ZclCommandTransmitter.class);
     /**
      * The network manager for transmitting data to and from network layer.
      */
@@ -56,7 +59,9 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
 
     /**
      * Constructor for setting network manager.
-     * @param networkManager the network manager
+     * 
+     * @param networkManager
+     *            the network manager
      */
     public ZclCommandTransmitter(final ZigBeeNetworkManagerImpl networkManager) {
         this.networkManager = networkManager;
@@ -64,42 +69,47 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
 
     /**
      * Adds command listener.
-     * @param listener the command listener
+     * 
+     * @param listener
+     *            the command listener
      */
     public void addCommandListener(final CommandListener listener) {
-        final List<CommandListener> modifiedCommandListeners = new ArrayList<CommandListener>(commandListeners);
+        final List<CommandListener> modifiedCommandListeners = new ArrayList<CommandListener>(
+                commandListeners);
         modifiedCommandListeners.add(listener);
-        commandListeners = Collections.unmodifiableList(modifiedCommandListeners);
+        commandListeners = Collections
+                .unmodifiableList(modifiedCommandListeners);
     }
 
     /**
      * Removes command listener.
-     * @param listener the command listener
+     * 
+     * @param listener
+     *            the command listener
      */
     public void removeCommandListener(final CommandListener listener) {
-        final List<CommandListener> modifiedCommandListeners = new ArrayList<CommandListener>(commandListeners);
+        final List<CommandListener> modifiedCommandListeners = new ArrayList<CommandListener>(
+                commandListeners);
         modifiedCommandListeners.remove(listener);
-        commandListeners = Collections.unmodifiableList(modifiedCommandListeners);
+        commandListeners = Collections
+                .unmodifiableList(modifiedCommandListeners);
     }
 
     @Override
     public boolean notify(final AF_INCOMING_MSG clusterMessage) {
 
-        final ZCLFrame frame = new ZCLFrame(new ClusterMessageImpl(clusterMessage.getData(),
-                clusterMessage.getClusterId()));
+        final ZCLFrame frame = new ZCLFrame(new ClusterMessageImpl(
+                clusterMessage.getData(), clusterMessage.getClusterId()));
 
-        final boolean isClientServerDirection = frame.getHeader().getFramecontrol().isClientServerDirection();
-        final boolean isClusterSpecificCommand = frame.getHeader().getFramecontrol().isClusterSpecificCommand();
-        final boolean isManufacturerExtension = frame.getHeader().getFramecontrol().isManufacturerExtension();
-        final boolean isDefaultResponseEnabled = frame.getHeader().getFramecontrol().isDefaultResponseEnabled();
+        final boolean isClientServerDirection = frame.getHeader()
+                .getFramecontrol().isClientServerDirection();
+        final boolean isClusterSpecificCommand = frame.getHeader()
+                .getFramecontrol().isClusterSpecificCommand();
+        final boolean isManufacturerExtension = frame.getHeader()
+                .getFramecontrol().isManufacturerExtension();
+        final boolean isDefaultResponseEnabled = frame.getHeader()
+                .getFramecontrol().isDefaultResponseEnabled();
 
-        final int sourceAddress = clusterMessage.getSrcAddr();
-        final short sourceEndpoint = clusterMessage.getSrcEndpoint();
-        final int destinationAddress = 0;
-        final short destinationEndpoint = clusterMessage.getDstEndpoint();
-
-        final int profileId = ApplicationFrameworkLayer.getAFLayer(networkManager).getSenderEndpointProfileId(
-                destinationEndpoint, clusterMessage.getClusterId());
         int clusterId = clusterMessage.getClusterId();
         final byte commandId = frame.getHeader().getCommandId();
         final byte transactionId = frame.getHeader().getTransactionId();
@@ -107,35 +117,48 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
         final byte[] commandPayload = frame.getPayload();
 
         LOGGER.debug("Received command: [ clusterId: " + clusterId
-                + " commandId: " + commandId
-                + " specific: " + isClusterSpecificCommand
-                + " extension: " + isManufacturerExtension
-                + " ZCL Header: " + ByteUtils.toBase16(frame.getHeader().toByte())
+                + " commandId: " + commandId + " specific: "
+                + isClusterSpecificCommand + " extension: "
+                + isManufacturerExtension + " ZCL Header: "
+                + ByteUtils.toBase16(frame.getHeader().toByte())
                 + ", ZCL Payload: " + ByteUtils.toBase16(frame.getPayload())
                 + "]");
 
         if (isManufacturerExtension) {
             return false;
         }
+        
+        final int sourceAddress = clusterMessage.getSrcAddr();
+        final short sourceEndpoint = clusterMessage.getSrcEndpoint();
+        final int destinationAddress = 0;
+        final short destinationEndpoint = clusterMessage.getDstEndpoint();
 
+        final int profileId = ApplicationFrameworkLayer.getAFLayer(
+                networkManager).getSenderEndpointProfileId(destinationEndpoint,
+                clusterMessage.getClusterId());
         final ZclCommandMessage commandMessage = new ZclCommandMessage();
         commandMessage.setClusterId(clusterId);
-        commandMessage.setSourceAddress(new ZigBeeDeviceAddress(sourceAddress, sourceEndpoint & 0xffff));
-//        commandMessage.setSourceEndpoint(sourceEnpoint & (0xFFFF));
-        commandMessage.setDestinationAddress(new ZigBeeDeviceAddress(destinationAddress, destinationEndpoint & 0xffff));
-//        commandMessage.setDestinationEndpoint(destinationEndpoint & (0xFFFF));
+        commandMessage.setSourceAddress(new ZigBeeDeviceAddress(sourceAddress,
+                sourceEndpoint & 0xffff));
+        // commandMessage.setSourceEndpoint(sourceEnpoint & (0xFFFF));
+        commandMessage.setDestinationAddress(new ZigBeeDeviceAddress(
+                destinationAddress, destinationEndpoint & 0xffff));
+        // commandMessage.setDestinationEndpoint(destinationEndpoint &
+        // (0xFFFF));
         commandMessage.setTransactionId(transactionId);
 
         ZclCommandType command = null;
         if (isClusterSpecificCommand) {
-            LOGGER.debug("Received cluster specific command: [ clusterId: " + clusterId
-                    + " commandId: " + commandId + " ZCL Header: " + ByteUtils.toBase16(frame.getHeader().toByte())
-                    + ", ZCL Payload: " + ByteUtils.toBase16(frame.getPayload())
-                    + "]");
+            LOGGER.debug("Received cluster specific command: [ clusterId: "
+                    + clusterId + " commandId: " + commandId + " ZCL Header: "
+                    + ByteUtils.toBase16(frame.getHeader().toByte())
+                    + ", ZCL Payload: "
+                    + ByteUtils.toBase16(frame.getPayload()) + "]");
 
             for (final ZclCommandType candidate : ZclCommandType.values()) {
-                if (candidate.getClusterType().getProfileType().getId() == profileId && candidate.getClusterType().getId() == clusterId
-                        && candidate.getId() == (commandId  & (0xFF))
+                if (candidate.getClusterType().getProfileType().getId() == profileId
+                        && candidate.getClusterType().getId() == clusterId
+                        && candidate.getId() == (commandId & (0xFF))
                         && candidate.isReceived() == isClientServerDirection) {
                     command = candidate;
                     break;
@@ -143,13 +166,15 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
             }
         } else {
             LOGGER.debug("Received general command: [ clusterId: " + clusterId
-                    + " commandId: " + commandId + " ZCL Header: " + ByteUtils.toBase16(frame.getHeader().toByte())
-                    + ", ZCL Payload: " + ByteUtils.toBase16(frame.getPayload())
-                    + "]");
+                    + " commandId: " + commandId + " ZCL Header: "
+                    + ByteUtils.toBase16(frame.getHeader().toByte())
+                    + ", ZCL Payload: "
+                    + ByteUtils.toBase16(frame.getPayload()) + "]");
 
             for (final ZclCommandType candidate : ZclCommandType.values()) {
-                if (candidate.getClusterType().getProfileType().getId() == profileId && candidate.isGeneric()
-                        && candidate.getId() == (commandId  & (0xFF))) {
+                if (candidate.getClusterType().getProfileType().getId() == profileId
+                        && candidate.isGeneric()
+                        && candidate.getId() == (commandId & (0xFF))) {
                     command = candidate;
                     break;
                 }
@@ -174,17 +199,17 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
 
     /**
      * Sends command message.
-     * @param commandMessage the command message
+     * 
+     * @param commandMessage
+     *            the command message
      * @return transaction ID
      * @throws ZigBeeNetworkManagerException
      */
-    public int sendCommand(final ZclCommandMessage commandMessage) throws ZigBeeException {
+    public int sendCommand(final ZclCommandMessage commandMessage)
+            throws ZigBeeException {
         synchronized (networkManager) {
-            final ApplicationFrameworkLayer af = ApplicationFrameworkLayer.getAFLayer(networkManager);
-
-            // TODO load properly dongle source address
-//            final int sourceAddress = commandMessage.getSourceAddress();
-  //          commandMessage.setSourceAddress(sourceAddress);
+            final ApplicationFrameworkLayer af = ApplicationFrameworkLayer
+                    .getAFLayer(networkManager);
 
             final int clusterId;
             if (commandMessage.getType().isGeneric()) {
@@ -194,33 +219,47 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
             }
             commandMessage.setClusterId(clusterId);
 
-            commandMessage.setSourceEndpoint(
-                    af.getSendingEndpoint(commandMessage.getType().getClusterType().getProfileType().getId(),
-                    clusterId));
+            // TODO load properly dongle source address
+            ZigBeeAddress sourceAddress = new ZigBeeDeviceAddress(0,
+                    af.getSendingEndpoint(commandMessage.getType()
+                            .getClusterType().getProfileType().getId(),
+                            clusterId));
+            commandMessage.setSourceAddress(sourceAddress);
 
-            final byte[] payload = ZclCommandProtocol.serializePayload(commandMessage);
+            final byte[] payload = ZclCommandProtocol
+                    .serializePayload(commandMessage);
 
-            final AbstractCommand cmd = new AbstractCommand((byte) commandMessage.getType().getId(), null,
-                    commandMessage.getType().isGeneric() ? true  : commandMessage.getType().isReceived(), !commandMessage.getType().isGeneric());
+            final AbstractCommand cmd = new AbstractCommand(
+                    (byte) commandMessage.getType().getId(), null,
+                    commandMessage.getType().isGeneric() ? true
+                            : commandMessage.getType().isReceived(),
+                    !commandMessage.getType().isGeneric());
             cmd.setPayload(payload);
             final ZCLFrame zclFrame = new ZCLFrame(cmd, true);
             if (commandMessage.getTransactionId() != null) {
-                zclFrame.getHeader().setTransactionId(commandMessage.getTransactionId());
+                zclFrame.getHeader().setTransactionId(
+                        commandMessage.getTransactionId());
             }
             final ClusterMessage input = new org.bubblecloud.zigbee.api.cluster.impl.ClusterMessageImpl(
                     (short) clusterId, zclFrame);
 
-            final short sender = af.getSendingEndpoint(commandMessage.getType().getClusterType().getProfileType().getId(), clusterId);
+            final short sender = af.getSendingEndpoint(commandMessage.getType()
+                    .getClusterType().getProfileType().getId(), clusterId);
             final byte afTransactionId = af.getNextTransactionId(sender);
             final byte[] msg = input.getClusterMsg();
 
             if (commandMessage.getDestinationGroupId() == null) {
-            	ZigBeeDeviceAddress destination = (ZigBeeDeviceAddress) commandMessage.getDestinationAddress();
-                final AF_DATA_CONFIRM response = networkManager.sendAFDataRequest(new AF_DATA_REQUEST(
-                		destination.getAddress(), (short) destination.getEndpoint(), sender,
-                        input.getId(), afTransactionId, (byte) (0) /*options*/, (byte) 0 /*radius*/, msg));
+                ZigBeeDeviceAddress destination = (ZigBeeDeviceAddress) commandMessage
+                        .getDestinationAddress();
+                final AF_DATA_CONFIRM response = networkManager
+                        .sendAFDataRequest(new AF_DATA_REQUEST(destination
+                                .getAddress(), (short) destination
+                                .getEndpoint(), sender, input.getId(),
+                                afTransactionId, (byte) (0) /* options */,
+                                (byte) 0 /* radius */, msg));
 
-                commandMessage.setTransactionId(zclFrame.getHeader().getTransactionId());
+                commandMessage.setTransactionId(zclFrame.getHeader()
+                        .getTransactionId());
                 LOGGER.debug(">>> " + commandMessage.toString());
 
                 if (response == null) {
@@ -228,24 +267,35 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
                             "Unable to send cluster on the ZigBee network due to general error.");
                 }
 
-                if (response.getStatus()  != 0) {
-                    throw new ZigBeeException("Unable to send cluster on the ZigBee network due to: "
-                            + ResponseStatus.getStatus(response.getStatus())
-                            + " " + (response.getErrorMsg() != null ? " - " + response.getErrorMsg() : "") + ")");
+                if (response.getStatus() != 0) {
+                    throw new ZigBeeException(
+                            "Unable to send cluster on the ZigBee network due to: "
+                                    + ResponseStatus.getStatus(response
+                                            .getStatus())
+                                    + " "
+                                    + (response.getErrorMsg() != null ? " - "
+                                            + response.getErrorMsg() : "")
+                                    + ")");
                 }
 
                 return commandMessage.getTransactionId();
 
             } else {
-               final AfDataSrspExt response = networkManager.sendAFDataRequestExt(new AfDataRequestExt(
-                        commandMessage.getDestinationGroupId(), sender,
-                        input.getId(), afTransactionId, (byte) (0) /*options*/, (byte) 0 /*radius*/, msg));
-                commandMessage.setTransactionId(zclFrame.getHeader().getTransactionId());
+                final AfDataSrspExt response = networkManager
+                        .sendAFDataRequestExt(new AfDataRequestExt(
+                                commandMessage.getDestinationGroupId(), sender,
+                                input.getId(), afTransactionId,
+                                (byte) (0) /* options */,
+                                (byte) 0 /* radius */, msg));
+                commandMessage.setTransactionId(zclFrame.getHeader()
+                        .getTransactionId());
                 LOGGER.debug(">>> " + commandMessage.toString());
 
-                if (response.getStatus()  != 0) {
-                    throw new ZigBeeException("Unable to send cluster on the ZigBee network due to: "
-                            + ResponseStatus.getStatus(response.getStatus()));
+                if (response.getStatus() != 0) {
+                    throw new ZigBeeException(
+                            "Unable to send cluster on the ZigBee network due to: "
+                                    + ResponseStatus.getStatus(response
+                                            .getStatus()));
                 }
 
                 return commandMessage.getTransactionId();

--- a/zigbee-dongle-cc2531/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommandTransmitter.java
+++ b/zigbee-dongle-cc2531/src/main/java/org/bubblecloud/zigbee/v3/zcl/ZclCommandTransmitter.java
@@ -22,6 +22,7 @@ import org.bubblecloud.zigbee.network.ClusterMessage;
 import org.bubblecloud.zigbee.network.packet.ResponseStatus;
 import org.bubblecloud.zigbee.network.packet.af.*;
 import org.bubblecloud.zigbee.v3.CommandListener;
+import org.bubblecloud.zigbee.v3.ZigBeeDeviceAddress;
 import org.bubblecloud.zigbee.network.impl.*;
 import org.bubblecloud.zigbee.v3.ZigBeeException;
 import org.bubblecloud.zigbee.v3.model.Status;
@@ -93,7 +94,7 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
         final boolean isDefaultResponseEnabled = frame.getHeader().getFramecontrol().isDefaultResponseEnabled();
 
         final int sourceAddress = clusterMessage.getSrcAddr();
-        final short sourceEnpoint = clusterMessage.getSrcEndpoint();
+        final short sourceEndpoint = clusterMessage.getSrcEndpoint();
         final int destinationAddress = 0;
         final short destinationEndpoint = clusterMessage.getDstEndpoint();
 
@@ -119,10 +120,10 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
 
         final ZclCommandMessage commandMessage = new ZclCommandMessage();
         commandMessage.setClusterId(clusterId);
-        commandMessage.setSourceAddress(sourceAddress);
-        commandMessage.setSourceEnpoint(sourceEnpoint & (0xFFFF));
-        commandMessage.setDestinationAddress(destinationAddress);
-        commandMessage.setDestinationEndpoint(destinationEndpoint & (0xFFFF));
+        commandMessage.setSourceAddress(new ZigBeeDeviceAddress(sourceAddress, sourceEndpoint & 0xffff));
+//        commandMessage.setSourceEndpoint(sourceEnpoint & (0xFFFF));
+        commandMessage.setDestinationAddress(new ZigBeeDeviceAddress(destinationAddress, destinationEndpoint & 0xffff));
+//        commandMessage.setDestinationEndpoint(destinationEndpoint & (0xFFFF));
         commandMessage.setTransactionId(transactionId);
 
         ZclCommandType command = null;
@@ -182,8 +183,8 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
             final ApplicationFrameworkLayer af = ApplicationFrameworkLayer.getAFLayer(networkManager);
 
             // TODO load properly dongle source address
-            final int sourceAddress = commandMessage.getSourceAddress();
-            commandMessage.setSourceAddress(sourceAddress);
+//            final int sourceAddress = commandMessage.getSourceAddress();
+  //          commandMessage.setSourceAddress(sourceAddress);
 
             final int clusterId;
             if (commandMessage.getType().isGeneric()) {
@@ -193,7 +194,7 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
             }
             commandMessage.setClusterId(clusterId);
 
-            commandMessage.setSourceEnpoint(
+            commandMessage.setSourceEndpoint(
                     af.getSendingEndpoint(commandMessage.getType().getClusterType().getProfileType().getId(),
                     clusterId));
 
@@ -214,8 +215,9 @@ public class ZclCommandTransmitter implements ApplicationFrameworkMessageListene
             final byte[] msg = input.getClusterMsg();
 
             if (commandMessage.getDestinationGroupId() == null) {
+            	ZigBeeDeviceAddress destination = (ZigBeeDeviceAddress) commandMessage.getDestinationAddress();
                 final AF_DATA_CONFIRM response = networkManager.sendAFDataRequest(new AF_DATA_REQUEST(
-                        commandMessage.getDestinationAddress(), (short) commandMessage.getDestinationEndpoint(), sender,
+                		destination.getAddress(), (short) destination.getEndpoint(), sender,
                         input.getId(), afTransactionId, (byte) (0) /*options*/, (byte) 0 /*radius*/, msg));
 
                 commandMessage.setTransactionId(zclFrame.getHeader().getTransactionId());

--- a/zigbee-gateway-client/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeGatewayClient.java
+++ b/zigbee-gateway-client/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeGatewayClient.java
@@ -83,12 +83,12 @@ public class ZigBeeGatewayClient extends ZigBeeApi implements ZigBeeNetwork {
     }
 
     @Override
-    public ZigBeeGroup getGroup(final int groupId) {
+    public ZigBeeGroupAddress getGroup(final int groupId) {
         return rpcClient.getZigBeeRpcApi().getGroup(groupId);
     }
 
     @Override
-    public List<ZigBeeGroup> getGroups() {
+    public List<ZigBeeGroupAddress> getGroups() {
         return rpcClient.getZigBeeRpcApi().getGroups();
     }
 

--- a/zigbee-gateway-client/src/test/java/org/bubblecloud/zigbee/ZigBeeGatewayClientTest.java
+++ b/zigbee-gateway-client/src/test/java/org/bubblecloud/zigbee/ZigBeeGatewayClientTest.java
@@ -7,6 +7,7 @@ import org.bubblecloud.zigbee.v3.Command;
 import org.junit.Assert;
 import org.bubblecloud.zigbee.v3.CommandListener;
 import org.bubblecloud.zigbee.v3.ZigBeeDevice;
+import org.bubblecloud.zigbee.v3.ZigBeeDeviceAddress;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -36,31 +37,31 @@ public class ZigBeeGatewayClientTest {
 
 
         final ReadAttributesCommand readAttributesCommand = new ReadAttributesCommand();
-        readAttributesCommand.setDestinationAddress(11022);
-        readAttributesCommand.setDestinationEndpoint(11);
+        ZigBeeDeviceAddress address = new ZigBeeDeviceAddress(11022,11);
+        readAttributesCommand.setDestinationAddress(address);
         readAttributesCommand.setClusterId(0);
         readAttributesCommand.setIdentifiers(new ArrayList<AttributeIdentifier>(Arrays.asList(new AttributeIdentifier())));
         client.sendCommand(readAttributesCommand);
 
         final ZigBeeDevice device = client.getDevices().get(3);
 
-        Assert.assertTrue(client.on(device).get().isSuccess());
+        Assert.assertTrue(client.on(address).get().isSuccess());
 
         Thread.sleep(1000);
 
-        Assert.assertTrue(client.color(device, 1.0, 0.0, 0.0, 1.0).get().isSuccess());
+        Assert.assertTrue(client.color(address, 1.0, 0.0, 0.0, 1.0).get().isSuccess());
 
         Thread.sleep(1000);
 
-        Assert.assertTrue(client.color(device, 0.0, 1.0, 0.0, 1.0).get().isSuccess());
+        Assert.assertTrue(client.color(address, 0.0, 1.0, 0.0, 1.0).get().isSuccess());
 
         Thread.sleep(1000);
 
-        Assert.assertTrue(client.color(device, 0.0, 0.0, 1.0, 1.0).get().isSuccess());
+        Assert.assertTrue(client.color(address, 0.0, 0.0, 1.0, 1.0).get().isSuccess());
 
         Thread.sleep(1000);
 
-        Assert.assertTrue(client.off(device).get().isSuccess());
+        Assert.assertTrue(client.off(address).get().isSuccess());
 
         /*final ReadAttributesCommand readAttributesCommand = new ReadAttributesCommand();
         readAttributesCommand.setDestinationAddress(11022);

--- a/zigbee-gateway-server/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeGateway.java
+++ b/zigbee-gateway-server/src/main/java/org/bubblecloud/zigbee/v3/ZigBeeGateway.java
@@ -269,22 +269,22 @@ public final class ZigBeeGateway {
      * @param destinationIdentifier the device identifier or group ID
      * @return the device
      */
-    private ZigBeeDestination getDestination(final ZigBeeApiDongleImpl zigbeeApi, final String destinationIdentifier
+    private ZigBeeAddress getDestination(final ZigBeeApiDongleImpl zigbeeApi, final String destinationIdentifier
             ,final PrintStream out) {
         final ZigBeeDevice device = getDevice(zigbeeApi, destinationIdentifier);
 
         if (device != null) {
-            return device;
+            return device.getDeviceAddress();
         }
 
         try {
-            for (final ZigBeeGroup group : zigbeeApi.getGroups()) {
+            for (final ZigBeeGroupAddress group : zigbeeApi.getGroups()) {
                 if (destinationIdentifier.equals(group.getLabel())) {
                     return group;
                 }
             }
             final int groupId = Integer.parseInt(destinationIdentifier);
-            ZigBeeGroup group = zigbeeApi.getGroup(groupId);
+            ZigBeeGroupAddress group = zigbeeApi.getGroup(groupId);
             if (group == null) {
                 zigBeeApi.addMembership(groupId, Integer.toString(groupId));
             }
@@ -457,8 +457,8 @@ public final class ZigBeeGateway {
          * {@inheritDoc}
          */
         public boolean process(final ZigBeeApiDongleImpl zigbeeApi, final String[] args, PrintStream out) {
-            final List<ZigBeeGroup> groups = zigbeeApi.getGroups();
-            for (final ZigBeeGroup group : groups) {
+            final List<ZigBeeGroupAddress> groups = zigbeeApi.getGroups();
+            for (final ZigBeeGroupAddress group : groups) {
                 print(StringUtils.leftPad(Integer.toString(group.getGroupId()), 10) + "      " + group.getLabel(), out);
             }
             return true;
@@ -646,7 +646,7 @@ public final class ZigBeeGateway {
                 return false;
             }
 
-            final ZigBeeDestination destination = getDestination(zigbeeApi, args[1], out);
+            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
 
             if (destination == null) {
                 return false;
@@ -682,7 +682,7 @@ public final class ZigBeeGateway {
                 return false;
             }
 
-            final ZigBeeDestination destination = getDestination(zigbeeApi, args[1], out);
+            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
 
             if (destination == null) {
                 return false;
@@ -717,7 +717,7 @@ public final class ZigBeeGateway {
                 return false;
             }
 
-            final ZigBeeDestination destination = getDestination(zigbeeApi, args[1], out);
+            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
             if (destination == null) {
                 return false;
             }
@@ -879,15 +879,15 @@ public final class ZigBeeGateway {
                 return false;
             }
 
-            final ZigBeeDestination destination = getDestination(zigbeeApi, args[1], out);
+            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
             if (destination == null) {
                 return false;
             }
-            if (!(destination instanceof ZigBeeGroup)) {
+            if (!(destination instanceof ZigBeeGroupAddress)) {
                 return false;
             }
 
-            final ZigBeeGroup group = (ZigBeeGroup) destination;
+            final ZigBeeGroupAddress group = (ZigBeeGroupAddress) destination;
             zigbeeApi.removeMembership(group.getGroupId());
             return true;
         }
@@ -954,7 +954,7 @@ public final class ZigBeeGateway {
                 return false;
             }
 
-            final ZigBeeDestination destination = getDestination(zigbeeApi, args[1], out);
+            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
             if (destination == null) {
                 return false;
             }
@@ -995,7 +995,7 @@ public final class ZigBeeGateway {
                 return false;
             }
 
-            final ZigBeeDestination destination = getDestination(zigbeeApi, args[1], out);
+            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
             if (destination == null) {
                 return false;
             }
@@ -1031,7 +1031,7 @@ public final class ZigBeeGateway {
                 return false;
             }
 
-            final ZigBeeDestination destination = getDestination(zigbeeApi, args[1], out);
+            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
             if (destination == null) {
                 return false;
             }
@@ -1448,7 +1448,7 @@ public final class ZigBeeGateway {
                 return false;
             }
 
-            final ZigBeeDestination destination = getDestination(zigbeeApi, args[1], out);
+            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
             if (destination == null) {
                 print("Device not found.", out);
                 return false;
@@ -1512,7 +1512,7 @@ public final class ZigBeeGateway {
                 return false;
             }
 
-            final ZigBeeDestination destination = getDestination(zigbeeApi, args[1], out);
+            final ZigBeeAddress destination = getDestination(zigbeeApi, args[1], out);
             if (destination == null) {
                 print("Device not found.", out);
                 return false;

--- a/zigbee-gateway-server/src/main/java/org/bubblecloud/zigbee/v3/rpc/ZigBeeRpcApiImpl.java
+++ b/zigbee-gateway-server/src/main/java/org/bubblecloud/zigbee/v3/rpc/ZigBeeRpcApiImpl.java
@@ -117,12 +117,12 @@ public class ZigBeeRpcApiImpl implements ZigBeeRpcApi, CommandListener {
     }
 
     @Override
-    public ZigBeeGroup getGroup(int groupId) {
+    public ZigBeeGroupAddress getGroup(int groupId) {
         return zigBeeGateway.getZigBeeApi().getGroup(groupId);
     }
 
     @Override
-    public List<ZigBeeGroup> getGroups() {
+    public List<ZigBeeGroupAddress> getGroups() {
         return zigBeeGateway.getZigBeeApi().getGroups();
     }
 


### PR DESCRIPTION
This is an updated version of #95. I've now updated the doc and removed commented code.

This changes the ZigBeeDestination to ZigBeeAddress, and then has two address classes - ZigBeeGroupAddress, and ZigBeeDeviceAddress. ZigBeeDevice no longer extends ZigBeeDestination - nothing relied on this extension, and it seems much better not to have this link.

It also makes ZigBeeAddress abstract, and then move the isGroup method into the implementation classes rather than having the parent class check for subclasses to see if it's a group which doesn't seem nice.

In general, everywhere where we had a network address and endpoint, I'm now using the address. It likely needs a bit more work, but I'd welcome your thoughts on wether or not you're happy with this approach.
