### PR TITLE
Addition of JSerialComm as port library

### DIFF
--- a/zigbee-serial-jserialcomm/build.gradle
+++ b/zigbee-serial-jserialcomm/build.gradle
@@ -1,0 +1,18 @@
+apply from: '../build-common-javase.gradle'
+apply from: '../build-common.gradle'
+
+repositories {
+    jcenter()
+    mavenLocal()
+    mavenCentral()
+    maven { url "http://repository-bubblecloud.forge.cloudbees.com/release/" }
+    maven { url "http://repo.maven.apache.org/maven2" }
+}
+
+dependencies {
+    implementation 'com.fazecast:jSerialComm:2.6.2'
+    implementation project(':zigbee-api')
+
+    testCompile project(':zigbee-api')
+    testCompile project(path: ':zigbee-api', configuration: 'testOutput')
+}

--- a/zigbee-serial-jserialcomm/pom.xml
+++ b/zigbee-serial-jserialcomm/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>zigbee-serial-jserialcomm</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.bubblecloud.zigbee4java</groupId>
+        <artifactId>zigbee4java</artifactId>
+        <version>3.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.bubblecloud.zigbee4java</groupId>
+            <artifactId>zigbee-common</artifactId>
+            <version>3.1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fazecast</groupId>
+            <artifactId>jSerialComm</artifactId>
+            <version>2.6.2</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/zigbee-serial-jserialcomm/src/main/java/org/bubblecloud/zigbee/network/port/SerialPortJSC.java
+++ b/zigbee-serial-jserialcomm/src/main/java/org/bubblecloud/zigbee/network/port/SerialPortJSC.java
@@ -37,6 +37,7 @@ public class SerialPortJSC implements org.bubblecloud.zigbee.v3.SerialPort {
 
     /**
      * Constructor setting port name and baud rate.
+     *
      * @param portName the port name
      * @param baudRate the baud rate
      */
@@ -75,6 +76,9 @@ public class SerialPortJSC implements org.bubblecloud.zigbee.v3.SerialPort {
 
     @Override
     public void close() {
+        if (serialPort == null)
+            return;
+
         try {
             inputStream.close();
             outputStream.flush();

--- a/zigbee-serial-jserialcomm/src/main/java/org/bubblecloud/zigbee/network/port/SerialPortJSC.java
+++ b/zigbee-serial-jserialcomm/src/main/java/org/bubblecloud/zigbee/network/port/SerialPortJSC.java
@@ -1,0 +1,103 @@
+package se.hal.plugin.zigbee;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.fazecast.jSerialComm.SerialPort;
+
+/**
+ * Wrapper for usage of JSerialComm library with Zigbee4Java
+ *
+ * @author Ziver Koc
+ */
+public class SerialPortJSC implements org.bubblecloud.zigbee.v3.SerialPort {
+    private final static Logger LOGGER = LoggerFactory.getLogger(SerialPortJSC.class);
+
+    /**
+     * The default baud rate.
+     */
+    public static final int DEFAULT_BAUD_RATE = 38400;
+
+    private final String portName;
+    private final int baudRate;
+
+    private SerialPort serialPort;
+    private InputStream inputStream;
+    private OutputStream outputStream;
+
+    /**
+     * Constructor which sets port name to given value and baud rate to default.
+     */
+    public SerialPortJSC(final String portName) {
+        this(portName, DEFAULT_BAUD_RATE);
+    }
+
+    /**
+     * Constructor setting port name and baud rate.
+     * @param portName the port name
+     * @param baudRate the baud rate
+     */
+    public SerialPortJSC(final String portName, final int baudRate) {
+        this.portName = portName;
+        this.baudRate = baudRate;
+    }
+
+
+    @Override
+    public boolean open() {
+        if (serialPort != null) {
+            throw new RuntimeException("Serial port already open.");
+        }
+
+        try {
+            LOGGER.info("Connecting to com port... (" + portName + ")");
+            serialPort = SerialPort.getCommPort(portName);
+            serialPort.setBaudRate(baudRate);
+            serialPort.setComPortTimeouts(
+                    SerialPort.TIMEOUT_READ_BLOCKING, 0, 0);
+
+            if (!serialPort.openPort()) {
+                LOGGER.error("Could not open port: " + portName);
+                return false;
+            }
+
+            outputStream = serialPort.getOutputStream();
+            inputStream = serialPort.getInputStream();
+            return true;
+        } catch (Exception e) {
+            LOGGER.warn("Unable to open serial port: " + e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            inputStream.close();
+            outputStream.flush();
+            outputStream.close();
+            serialPort.closePort();
+
+            LOGGER.info("Serial portName '" + portName + "' closed.");
+
+            serialPort = null;
+            inputStream = null;
+            outputStream = null;
+        } catch (Exception e) {
+            LOGGER.warn("Error closing portName portName: '" + portName + "'", e);
+        }
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return outputStream;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+}


### PR DESCRIPTION
I was unable to use the existing Serial port implementation, received JVM crash.

Solved my issue by using the newer JSerialComm library instead. I'm now able to connect to the serial port on Java 11.